### PR TITLE
track per-chunk value and outpayments in postage stamp

### DIFF
--- a/deploy/000_deploy_postage.ts
+++ b/deploy/000_deploy_postage.ts
@@ -3,9 +3,9 @@ import { DeployFunction } from 'hardhat-deploy/types';
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre;
-  const { deploy } = deployments;
+  const { deploy, execute, read } = deployments;
 
-  const { deployer } = await getNamedAccounts();
+  const { deployer, oracle } = await getNamedAccounts();
 
   const token = await deploy('ERC20PresetMinterPauser', {
     from: deployer,
@@ -18,6 +18,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     args: [token.address],
     log: true,
   });
+
+  const priceOracleRole = await read('PostageStamp', 'PRICE_ORACLE_ROLE');
+  await execute('PostageStamp', { from: deployer }, 'grantRole', priceOracleRole, oracle);
 };
 
 export default func;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -21,6 +21,7 @@ const config: HardhatUserConfig = {
     deployer: 0,
     admin: 1,
     stamper: 2,
+    oracle: 3,
   },
   networks: {
     hardhat: {

--- a/src/PostageStamp.sol
+++ b/src/PostageStamp.sol
@@ -1,59 +1,70 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity ^0.7.4;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
 
 /**
  * @title PostageStamp contract
  * @author The Swarm Authors
  * @dev The postage stamp contracts allows users to create and manage postage stamp batches.
  */
-contract PostageStamp {
+contract PostageStamp is AccessControl {
+    using SafeMath for uint256;
     /**
      * @dev Emitted when a new batch is created.
      */
-    event BatchCreated(bytes32 indexed batchId, uint256 initialBalance, address owner, uint8 depth);
+    event BatchCreated(bytes32 indexed batchId, uint256 totalAmount, uint256 normalisedBalance, address owner, uint8 depth);
 
     /**
      * @dev Emitted when an existing batch is topped up.
      */
-    event BatchTopUp(bytes32 indexed batchId, uint256 topupAmount);
+    event BatchTopUp(bytes32 indexed batchId, uint256 topupAmount, uint256 normalisedBalance);
 
     /**
      * @dev Emitted when the depth of an existing batch increases.
      */
-    event BatchDepthIncrease(bytes32 indexed batchId, uint8 newDepth);
+    event BatchDepthIncrease(bytes32 indexed batchId, uint8 newDepth, uint256 normalisedBalance);
 
     struct Batch {
         // Owner of this batch (0 if not valid).
         address owner;
         // Current depth of this batch.
         uint8 depth;
+        // Normalised balance per chunk.
+        uint256 normalisedBalance;
     }
+
+    // The role allowed to increase totalOutPayment
+    bytes32 public constant PRICE_ORACLE_ROLE = keccak256("PRICE_ORACLE");
 
     // Associate every batch id with batch data.
     mapping(bytes32 => Batch) public batches;
 
     // The address of the BZZ ERC20 token this contract references.
     address public bzzToken;
+    // The total out payment per chunk
+    uint256 public totalOutPayment;    
 
     /**
      * @param _bzzToken The ERC20 token address to reference in this contract.
      */
     constructor(address _bzzToken) {
         bzzToken = _bzzToken;
+        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
     }
 
     /**
      * @notice Create a new batch.
-     * @dev At least `initialBalance` number of tokens need to be preapproved for this contract.
+     * @dev At least `_initialBalancePerChunk*2^depth` number of tokens need to be preapproved for this contract.
      * @param _owner The owner of the new batch.
-     * @param _initialBalance The initial balance of the batch to be transferred into the contract.
+     * @param _initialBalancePerChunk The initial balance per chunk of the batch.
      * @param _depth The initial depth of the new batch.
      * @param _nonce A random value used in the batch id derivation to allow multiple batches per owner.
      */
     function createBatch(
         address _owner,
-        uint256 _initialBalance,
+        uint256 _initialBalancePerChunk,
         uint8 _depth,
         bytes32 _nonce
     ) external {
@@ -63,27 +74,37 @@ contract PostageStamp {
         bytes32 batchId = keccak256(abi.encode(msg.sender, _nonce));
         require(batches[batchId].owner == address(0), "batch already exists");
 
-        // TODO: check if we should call burn instead of transfer.
-        require(ERC20(bzzToken).transferFrom(msg.sender, address(this), _initialBalance), "failed transfer");
+        uint256 totalAmount = _initialBalancePerChunk.mul(1 << _depth);
+        require(ERC20(bzzToken).transferFrom(msg.sender, address(this), totalAmount), "failed transfer");
 
-        batches[batchId] = Batch({owner: _owner, depth: _depth});
+        uint256 normalisedBalance = totalOutPayment.add(_initialBalancePerChunk);
 
-        emit BatchCreated(batchId, _initialBalance, _owner, _depth);
+        batches[batchId] = Batch({
+            owner: _owner,
+            depth: _depth,
+            normalisedBalance: normalisedBalance
+        });
+
+        emit BatchCreated(batchId, totalAmount, normalisedBalance, _owner, _depth);
     }
 
     /**
      * @notice Top up an existing batch.
-     * @dev At least `topupAmount` number of tokens need to be preapproved for this contract.
+     * @dev At least `topupAmount*2^depth` number of tokens need to be preapproved for this contract.
      * @param _batchId The id of the existing batch.
-     * @param _topupAmount The amount of additional tokens to add.
+     * @param _topupAmountPerChunk The amount of additional tokens to add per chunk.
      */
-    function topUp(bytes32 _batchId, uint256 _topupAmount) external {
-        require(batches[_batchId].owner != address(0), "batch does not exist");
+    function topUp(bytes32 _batchId, uint256 _topupAmountPerChunk) external {
+        Batch storage batch = batches[_batchId];
+        require(batch.owner != address(0), "batch does not exist");
+        require(batch.normalisedBalance >= totalOutPayment, "batch already expired");
 
-        require(ERC20(bzzToken).transferFrom(msg.sender, address(this), _topupAmount), "failed transfer");
+        uint256 totalAmount = _topupAmountPerChunk.mul(1 << batch.depth);
+        require(ERC20(bzzToken).transferFrom(msg.sender, address(this), totalAmount), "failed transfer");
 
-        // NOTE: the topup amount is not stored - it is only tracked in events.
-        emit BatchTopUp(_batchId, _topupAmount);
+        batch.normalisedBalance = batch.normalisedBalance.add(_topupAmountPerChunk);
+        
+        emit BatchTopUp(_batchId, totalAmount, batch.normalisedBalance);
     }
 
     /**
@@ -96,8 +117,34 @@ contract PostageStamp {
         Batch storage batch = batches[_batchId];
         require(batch.owner == msg.sender, "not batch owner");
         require(_newDepth > batch.depth, "depth not increasing");
+        require(batch.normalisedBalance >= totalOutPayment, "batch already expired");
+
+        uint8 depthChange = _newDepth - batch.depth;
+        uint256 newRemainingBalance = remainingBalance(_batchId).div(1 << depthChange);
 
         batch.depth = _newDepth;
-        emit BatchDepthIncrease(_batchId, _newDepth);
+        batch.normalisedBalance = totalOutPayment.add(newRemainingBalance);
+
+        emit BatchDepthIncrease(_batchId, _newDepth, batch.normalisedBalance);
+    }
+
+    /**
+    * @notice Returns the per chunk balance not used up yet
+    * @param _batchId the id of the existing batch
+    */
+    function remainingBalance(bytes32 _batchId) view public returns (uint256) {
+        Batch storage batch = batches[_batchId];
+        require(batch.owner != address(0), "batch does not exist");
+        return batch.normalisedBalance.sub(totalOutPayment);
+    }
+
+    /**
+    * @notice Increase totalOutPayment
+    * @dev can only be called by the price oracle
+    * @param _totalOutPaymentIncrease the size of the increase
+    */
+    function increaseTotalOutPayment(uint256 _totalOutPaymentIncrease) external {
+        require(hasRole(PRICE_ORACLE_ROLE, msg.sender), "only price oracle can increase totalOutpayment");
+        totalOutPayment = totalOutPayment.add(_totalOutPaymentIncrease);
     }
 }

--- a/src/PostageStamp.sol
+++ b/src/PostageStamp.sol
@@ -74,6 +74,7 @@ contract PostageStamp is AccessControl {
         bytes32 batchId = keccak256(abi.encode(msg.sender, _nonce));
         require(batches[batchId].owner == address(0), "batch already exists");
 
+        // per chunk balance times the batch size is what we need to transfer in
         uint256 totalAmount = _initialBalancePerChunk.mul(1 << _depth);
         require(ERC20(bzzToken).transferFrom(msg.sender, address(this), totalAmount), "failed transfer");
 
@@ -99,6 +100,7 @@ contract PostageStamp is AccessControl {
         require(batch.owner != address(0), "batch does not exist");
         require(batch.normalisedBalance >= totalOutPayment, "batch already expired");
 
+        // per chunk topup amount times the batch size is what we need to transfer in
         uint256 totalAmount = _topupAmountPerChunk.mul(1 << batch.depth);
         require(ERC20(bzzToken).transferFrom(msg.sender, address(this), totalAmount), "failed transfer");
 
@@ -120,6 +122,7 @@ contract PostageStamp is AccessControl {
         require(batch.normalisedBalance >= totalOutPayment, "batch already expired");
 
         uint8 depthChange = _newDepth - batch.depth;
+        // divide by the change in batch size (2^depthChange)
         uint256 newRemainingBalance = remainingBalance(_batchId).div(1 << depthChange);
 
         batch.depth = _newDepth;

--- a/test/PostageStamp.test.ts
+++ b/test/PostageStamp.test.ts
@@ -4,6 +4,7 @@ import { ethers, deployments, getNamedAccounts, getUnnamedAccounts } from 'hardh
 // Named accounts used by tests.
 let stamper: string;
 let deployer: string;
+let oracle: string;
 let others: string[];
 
 // Before the tests, set named accounts and read deployments.
@@ -11,6 +12,7 @@ before(async function () {
   const namedAccounts = await getNamedAccounts();
   deployer = namedAccounts.deployer;
   stamper = namedAccounts.stamper;
+  oracle = namedAccounts.oracle;
   others = await getUnnamedAccounts();
 });
 
@@ -18,6 +20,10 @@ function computeBatchId(sender: string, nonce: string): string {
   const abi = new ethers.utils.AbiCoder();
   const encoded = abi.encode(['address', 'bytes32'], [sender, nonce]);
   return ethers.utils.keccak256(encoded);
+}
+
+async function increaseTotalOutPayment(outPayment: number) {
+  return await (await ethers.getContract('PostageStamp', oracle)).increaseTotalOutPayment(outPayment);
 }
 
 const zeroAddress = '0x0000000000000000000000000000000000000000';
@@ -38,6 +44,12 @@ describe('PostageStamp', function () {
       const token = await ethers.getContract('ERC20PresetMinterPauser');
       expect(await postageStamp.bzzToken()).to.be.eq(token.address);
     });
+
+    it('should assign the admin role', async function () {
+      const postageStamp = await ethers.getContract('PostageStamp');
+      const adminRole = await postageStamp.DEFAULT_ADMIN_ROLE();
+      expect(await postageStamp.hasRole(adminRole, deployer)).to.be.true;
+    });
   });
 
   describe('with deployed contract', async function () {
@@ -51,46 +63,73 @@ describe('PostageStamp', function () {
 
         this.batch = {
           nonce: '0x000000000000000000000000000000000000000000000000000000000000abcd',
-          initialPayment: 20,
+          initialPaymentPerChunk: 200,
           depth: 5,
         };
 
+        this.batchSize = 2 ** this.batch.depth;
+        this.transferAmount = this.batch.initialPaymentPerChunk * this.batchSize;
+        this.expectedNormalisedBalance = this.batch.initialPaymentPerChunk;
+
         this.batch.id = computeBatchId(stamper, this.batch.nonce);
 
-        await this.token.mint(stamper, this.batch.initialPayment);
+        await this.token.mint(stamper, this.transferAmount);
         (await ethers.getContract('ERC20PresetMinterPauser', stamper)).approve(
           this.postageStamp.address,
-          this.batch.initialPayment
+          this.transferAmount
         );
       });
 
       it('should fire the BatchCreated event', async function () {
         await expect(
-          this.postageStamp.createBatch(stamper, this.batch.initialPayment, this.batch.depth, this.batch.nonce)
+          this.postageStamp.createBatch(stamper, this.batch.initialPaymentPerChunk, this.batch.depth, this.batch.nonce)
         )
           .to.emit(this.postageStamp, 'BatchCreated')
-          .withArgs(this.batch.id, this.batch.initialPayment, stamper, this.batch.depth);
+          .withArgs(this.batch.id, this.transferAmount, this.expectedNormalisedBalance, stamper, this.batch.depth);
       });
 
       it('should store the batch', async function () {
-        await this.postageStamp.createBatch(stamper, this.batch.initialPayment, this.batch.depth, this.batch.nonce);
-        expect(await this.postageStamp.batches(this.batch.id)).to.deep.equal([stamper, this.batch.depth]);
+        await this.postageStamp.createBatch(
+          stamper,
+          this.batch.initialPaymentPerChunk,
+          this.batch.depth,
+          this.batch.nonce
+        );
+        const stamp = await this.postageStamp.batches(this.batch.id);
+        expect(stamp[0]).to.equal(stamper);
+        expect(stamp[1]).to.equal(this.batch.depth);
+        expect(stamp[2]).to.equal(this.expectedNormalisedBalance);
       });
 
       it('should transfer the token', async function () {
-        await this.postageStamp.createBatch(stamper, this.batch.initialPayment, this.batch.depth, this.batch.nonce);
+        await this.postageStamp.createBatch(
+          stamper,
+          this.batch.initialPaymentPerChunk,
+          this.batch.depth,
+          this.batch.nonce
+        );
         expect(await this.token.balanceOf(stamper)).to.equal(0);
       });
 
       it('should not create batch if insufficient funds', async function () {
         await expect(
-          this.postageStamp.createBatch(stamper, this.batch.initialPayment + 100, this.batch.depth, this.batch.nonce)
+          this.postageStamp.createBatch(
+            stamper,
+            this.batch.initialPaymentPerChunk + 1,
+            this.batch.depth,
+            this.batch.nonce
+          )
         ).to.be.revertedWith('ERC20: transfer amount exceeds balance');
       });
 
       it('should not allow zero address as owner', async function () {
         await expect(
-          this.postageStamp.createBatch(zeroAddress, this.batch.initialPayment, this.batch.depth, this.batch.nonce)
+          this.postageStamp.createBatch(
+            zeroAddress,
+            this.batch.initialPaymentPerChunk,
+            this.batch.depth,
+            this.batch.nonce
+          )
         ).to.be.revertedWith('owner cannot be the zero address');
       });
 
@@ -99,6 +138,25 @@ describe('PostageStamp', function () {
         await expect(this.postageStamp.createBatch(stamper, 0, this.batch.depth, this.batch.nonce)).to.be.revertedWith(
           'batch already exists'
         );
+      });
+
+      it('should include totalOutpayment in the normalised balance', async function () {
+        const outPayment = 100;
+        await increaseTotalOutPayment(100);
+
+        await expect(
+          this.postageStamp.createBatch(stamper, this.batch.initialPaymentPerChunk, this.batch.depth, this.batch.nonce)
+        )
+          .to.emit(this.postageStamp, 'BatchCreated')
+          .withArgs(
+            this.batch.id,
+            this.transferAmount,
+            outPayment + this.expectedNormalisedBalance,
+            stamper,
+            this.batch.depth
+          );
+        const stamp = await this.postageStamp.batches(this.batch.id);
+        expect(stamp[2]).to.equal(outPayment + this.expectedNormalisedBalance);
       });
     });
 
@@ -109,80 +167,119 @@ describe('PostageStamp', function () {
 
         this.batch = {
           nonce: '0x000000000000000000000000000000000000000000000000000000000000abcd',
-          initialPayment: 20,
+          initialPaymentPerChunk: 200,
           depth: 5,
         };
 
         this.batch.id = computeBatchId(stamper, this.batch.nonce);
-        this.topupAmount = 100;
+        this.topupAmountPerChunk = 100;
 
-        await this.token.mint(stamper, this.batch.initialPayment + this.topupAmount);
+        this.batchSize = 2 ** this.batch.depth;
+        this.initialNormalisedBalance = this.batch.initialPaymentPerChunk;
+        this.expectedNormalisedBalance = this.initialNormalisedBalance + this.topupAmountPerChunk;
+
+        await this.token.mint(stamper, (this.batch.initialPaymentPerChunk + this.topupAmountPerChunk) * this.batchSize);
         (await ethers.getContract('ERC20PresetMinterPauser', stamper)).approve(
           this.postageStamp.address,
-          this.batch.initialPayment + this.topupAmount
+          (this.batch.initialPaymentPerChunk + this.topupAmountPerChunk) * this.batchSize
         );
-        await this.postageStamp.createBatch(stamper, this.batch.initialPayment, this.batch.depth, this.batch.nonce);
+        await this.postageStamp.createBatch(
+          stamper,
+          this.batch.initialPaymentPerChunk,
+          this.batch.depth,
+          this.batch.nonce
+        );
       });
 
       it('should fire the BatchTopUp event', async function () {
-        await expect(this.postageStamp.topUp(this.batch.id, this.topupAmount))
+        await expect(this.postageStamp.topUp(this.batch.id, this.topupAmountPerChunk))
           .to.emit(this.postageStamp, 'BatchTopUp')
-          .withArgs(this.batch.id, this.topupAmount);
+          .withArgs(this.batch.id, this.topupAmountPerChunk * this.batchSize, this.expectedNormalisedBalance);
+      });
+
+      it('should update the normalised balance', async function () {
+        await this.postageStamp.topUp(this.batch.id, this.topupAmountPerChunk);
+        const stamp = await this.postageStamp.batches(this.batch.id);
+        expect(stamp[2]).to.equal(this.expectedNormalisedBalance);
       });
 
       it('should transfer the token', async function () {
-        await this.postageStamp.topUp(this.batch.id, this.topupAmount);
+        await this.postageStamp.topUp(this.batch.id, this.topupAmountPerChunk);
         expect(await this.token.balanceOf(stamper)).to.equal(0);
         expect(await this.token.balanceOf(this.postageStamp.address)).to.equal(
-          this.batch.initialPayment + this.topupAmount
+          (this.batch.initialPaymentPerChunk + this.topupAmountPerChunk) * this.batchSize
         );
       });
 
       it('should not top up non-existing batches', async function () {
-        const nonExistingBatchId = computeBatchId(deployer, this.batch.nonce)
-        await expect(
-          this.postageStamp.topUp(nonExistingBatchId, this.topupAmount)
-        ).to.be.revertedWith('batch does not exist');
+        const nonExistingBatchId = computeBatchId(deployer, this.batch.nonce);
+        await expect(this.postageStamp.topUp(nonExistingBatchId, this.topupAmountPerChunk)).to.be.revertedWith(
+          'batch does not exist'
+        );
       });
 
       it('should not top up with insufficient funds', async function () {
-        await expect(this.postageStamp.topUp(this.batch.id, this.topupAmount + 100)).to.be.revertedWith(
+        await expect(this.postageStamp.topUp(this.batch.id, this.topupAmountPerChunk + 1)).to.be.revertedWith(
           'ERC20: transfer amount exceeds balance'
+        );
+      });
+
+      it('should not top up expired batches', async function () {
+        await increaseTotalOutPayment(this.initialNormalisedBalance + 1);
+        await expect(this.postageStamp.topUp(this.batch.id, this.topupAmountPerChunk)).to.be.revertedWith(
+          'batch already expired'
         );
       });
     });
 
-    describe('when inceasing the depth', function () {
+    describe('when increasing the depth', function () {
       beforeEach(async function () {
         this.postageStamp = await ethers.getContract('PostageStamp', stamper);
         this.token = await ethers.getContract('ERC20PresetMinterPauser', deployer);
 
+        this.totalOutPayment = 100;
+        await increaseTotalOutPayment(this.totalOutPayment);
+
         this.batch = {
           nonce: '0x000000000000000000000000000000000000000000000000000000000000abcd',
-          initialPayment: 20,
+          initialPaymentPerChunk: 200000,
           depth: 5,
         };
 
         this.batch.id = computeBatchId(stamper, this.batch.nonce);
-        this.newDepth = 100;
+        this.newDepth = 10;
 
-        await this.token.mint(stamper, this.batch.initialPayment);
+        this.batchSize = 2 ** this.batch.depth;
+        this.newBatchSize = 2 ** this.newDepth;
+        this.initialNormalisedBalance = this.totalOutPayment + this.batch.initialPaymentPerChunk;
+        const transferAmount = this.batch.initialPaymentPerChunk * this.batchSize;
+        this.expectedNormalisedBalance = this.totalOutPayment + Math.floor(transferAmount / this.newBatchSize);
+
+        await this.token.mint(stamper, transferAmount);
         (await ethers.getContract('ERC20PresetMinterPauser', stamper)).approve(
           this.postageStamp.address,
-          this.batch.initialPayment
+          transferAmount
         );
-        await this.postageStamp.createBatch(stamper, this.batch.initialPayment, this.batch.depth, this.batch.nonce);
+        await this.postageStamp.createBatch(
+          stamper,
+          this.batch.initialPaymentPerChunk,
+          this.batch.depth,
+          this.batch.nonce
+        );
       });
 
       it('should fire the BatchDepthIncrease event', async function () {
         await expect(this.postageStamp.increaseDepth(this.batch.id, this.newDepth))
           .to.emit(this.postageStamp, 'BatchDepthIncrease')
-          .withArgs(this.batch.id, this.newDepth);
+          .withArgs(this.batch.id, this.newDepth, this.expectedNormalisedBalance);
       });
 
       it('should update the stamp data', async function () {
         await this.postageStamp.increaseDepth(this.batch.id, this.newDepth);
-        expect(await this.postageStamp.batches(this.batch.id)).to.deep.equal([stamper, this.newDepth]);
+        const stamp = await this.postageStamp.batches(this.batch.id);
+        expect(stamp[0]).to.equal(stamper);
+        expect(stamp[1]).to.equal(this.newDepth);
+        expect(stamp[2]).to.equal(this.expectedNormalisedBalance);
       });
 
       it('should not allow other accounts to increase depth', async function () {
@@ -199,6 +296,49 @@ describe('PostageStamp', function () {
       it('should not allow the same depth', async function () {
         await expect(this.postageStamp.increaseDepth(this.batch.id, this.batch.depth)).to.be.revertedWith(
           'depth not increasing'
+        );
+      });
+
+      it('should not increase depth of expired batches', async function () {
+        await increaseTotalOutPayment(this.batch.initialPaymentPerChunk + 1);
+        await expect(this.postageStamp.increaseDepth(this.batch.id, this.newDepth)).to.be.revertedWith(
+          'batch already expired'
+        );
+      });
+
+      it('should compute correct balance if outpayments changed since creation', async function () {
+        const outPaymentIncrease = 64;
+        await increaseTotalOutPayment(outPaymentIncrease);
+
+        const unusedPart = this.batch.initialPaymentPerChunk - outPaymentIncrease;
+        const currentOutPayment = this.totalOutPayment + outPaymentIncrease;
+
+        const expectedNormalisedBalance =
+          currentOutPayment + Math.floor((unusedPart * this.batchSize) / this.newBatchSize);
+
+        await expect(this.postageStamp.increaseDepth(this.batch.id, this.newDepth))
+          .to.emit(this.postageStamp, 'BatchDepthIncrease')
+          .withArgs(this.batch.id, this.newDepth, expectedNormalisedBalance);
+      });
+    });
+
+    describe('when increasing outpayment', function () {
+      it('should increase the outpayment if called by oracle', async function () {
+        const postageStamp = await ethers.getContract('PostageStamp', oracle);
+
+        const increase1 = 100;
+        await postageStamp.increaseTotalOutPayment(increase1);
+        expect(await postageStamp.totalOutPayment()).to.be.eq(increase1);
+
+        const increase2 = 200;
+        await postageStamp.increaseTotalOutPayment(increase2);
+        expect(await postageStamp.totalOutPayment()).to.be.eq(increase1 + increase2);
+      });
+
+      it('should revert if not called by oracle', async function () {
+        const postageStamp = await ethers.getContract('PostageStamp', deployer);
+        await expect(postageStamp.increaseTotalOutPayment(100)).to.be.revertedWith(
+          'only price oracle can increase totalOutpayment'
         );
       });
     });


### PR DESCRIPTION
based on https://hackmd.io/tvacCgfBSWmeConc3rFOtw

major deviations:
* topup and createBatch take the per chunk value as input
* uses zeppelin role system for oracle auth instead of storing it in an address

Does not include the price oracle which will be a separate pr.