### PR TITLE
refactor: Redistribution

### DIFF
--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -439,8 +439,9 @@ contract Redistribution is AccessControl, Pausable {
 
         // Get current truth
         (truthRevealedHash, truthRevealedDepth) = getCurrentTruth();
+        uint256 commitsArrayLength = currentCommits.length;
 
-        for (uint256 i = 0; i < currentCommits.length; i++) {
+        for (uint256 i = 0; i < commitsArrayLength; i++) {
             revIndex = currentCommits[i].revealIndex;
 
             // Deterministically read winner
@@ -537,8 +538,9 @@ contract Redistribution is AccessControl, Pausable {
         uint8 truthRevealedDepth;
         uint256 revIndex;
         string memory truthSelectionAnchor = currentTruthSelectionAnchor();
+        uint256 commitsArrayLength = currentCommits.length;
 
-        for (uint256 i = 0; i < currentCommits.length; i++) {
+        for (uint256 i = 0; i < commitsArrayLength; i++) {
             if (currentCommits[i].revealed) {
                 revIndex = currentCommits[i].revealIndex;
                 currentSum += currentReveals[revIndex].stakeDensity;
@@ -583,8 +585,10 @@ contract Redistribution is AccessControl, Pausable {
 
         // Get current truth
         (truthRevealedHash, truthRevealedDepth) = getCurrentTruth();
+        uint256 commitsArrayLength = currentCommits.length;
+        uint256 revealsArrayLength = currentReveals.length;
 
-        for (uint256 i = 0; i < currentCommits.length; i++) {
+        for (uint256 i = 0; i < commitsArrayLength; i++) {
             revIndex = currentCommits[i].revealIndex;
 
             // Select winner with valid truth
@@ -631,7 +635,7 @@ contract Redistribution is AccessControl, Pausable {
         }
 
         // Emit function Events
-        emit CountCommitsReveals(currentCommits.length, currentReveals.length);
+        emit CountCommitsReveals(commitsArrayLength, revealsArrayLength);
         emit TruthSelected(truthRevealedHash, truthRevealedDepth);
         emit WinnerSelected(winner);
 

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -164,7 +164,7 @@ contract Redistribution is AccessControl, Pausable {
     /**
      * @dev Emits the number of commits and reveals being processed by the claim phase.
      */
-    event CountCommitsReveals(uint256 _count, uint256 _count);
+    event CountCommitsReveals(uint256 _count, uint256 _count2);
 
     /**
      * @dev Logs that an overlay has committed

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -593,7 +593,6 @@ contract Redistribution is AccessControl, Pausable {
         }
 
         uint256 k = 0;
-
         string memory winnerSelectionAnchor = currentWinnerSelectionAnchor();
 
         for (uint256 i = 0; i < commitsArrayLength; i++) {
@@ -607,7 +606,6 @@ contract Redistribution is AccessControl, Pausable {
             ) {
                 currentWinnerSelectionSum += currentReveals[revIndex].stakeDensity;
                 randomNumber = keccak256(abi.encodePacked(winnerSelectionAnchor, k));
-
                 randomNumberTrunc = uint256(randomNumber & MaxH);
 
                 if (
@@ -643,14 +641,14 @@ contract Redistribution is AccessControl, Pausable {
             }
         }
 
+        // Emit function Events
         emit CountCommitsReveals(commitsArrayLength, revealsArrayLength);
         emit TruthSelected(truthRevealedHash, truthRevealedDepth);
         emit WinnerSelected(winner);
 
+        // Apply Important state changes
         PostageContract.withdraw(winner.owner);
-
         OracleContract.adjustPrice(uint256(k));
-
         currentClaimRound = cr;
     }
 }

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -162,14 +162,9 @@ contract Redistribution is AccessControl, Pausable {
 
     // Next two events to be removed after testing phase pending some other usefulness being found.
     /**
-     * @dev Emits the number of commits being processed by the claim phase.
+     * @dev Emits the number of commits and reveals being processed by the claim phase.
      */
-    event CountCommits(uint256 _count);
-
-    /**
-     * @dev Emits the number of reveals being processed by the claim phase.
-     */
-    event CountReveals(uint256 _count);
+    event CountCommitsReveals(uint256 _count, uint256 _count);
 
     /**
      * @dev Logs that an overlay has committed
@@ -573,10 +568,6 @@ contract Redistribution is AccessControl, Pausable {
 
         uint256 commitsArrayLength = currentCommits.length;
         uint256 revealsArrayLength = currentReveals.length;
-
-        emit CountCommits(commitsArrayLength);
-        emit CountReveals(revealsArrayLength);
-
         uint256 revIndex;
 
         for (uint256 i = 0; i < commitsArrayLength; i++) {
@@ -644,6 +635,7 @@ contract Redistribution is AccessControl, Pausable {
             }
         }
 
+        emit CountCommitsReveals(commitsArrayLength, revealsArrayLength);
         emit WinnerSelected(winner);
 
         PostageContract.withdraw(winner.owner);

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -142,11 +142,7 @@ contract Redistribution is AccessControl, Pausable {
      * @param postageContract the address of the linked PostageStamp contract.
      * @param oracleContract the address of the linked PriceOracle contract.
      */
-    constructor(
-        address staking,
-        address postageContract,
-        address oracleContract
-    ) {
+    constructor(address staking, address postageContract, address oracleContract) {
         Stakes = IStakeRegistry(staking);
         PostageContract = IPostageStamp(postageContract);
         OracleContract = IPriceOracle(oracleContract);
@@ -250,11 +246,7 @@ contract Redistribution is AccessControl, Pausable {
      * @param _overlay The overlay referenced in the pre-image. Must be staked by at least the minimum value,
      * and be derived from the same key pair as the message sender.
      */
-    function commit(
-        bytes32 _obfuscatedHash,
-        bytes32 _overlay,
-        uint256 _roundNumber
-    ) external whenNotPaused {
+    function commit(bytes32 _obfuscatedHash, bytes32 _overlay, uint256 _roundNumber) external whenNotPaused {
         require(currentPhaseCommit(), "not in commit phase");
         require(block.number % roundLength != (roundLength / 4) - 1, "can not commit in last block of phase");
         uint256 cr = currentRound();
@@ -344,15 +336,11 @@ contract Redistribution is AccessControl, Pausable {
      * @param B An overlay address to compare.
      * @param minimum Minimum proximity order.
      */
-    function inProximity(
-        bytes32 A,
-        bytes32 B,
-        uint8 minimum
-    ) public pure returns (bool) {
+    function inProximity(bytes32 A, bytes32 B, uint8 minimum) public pure returns (bool) {
         if (minimum == 0) {
             return true;
         }
-        return uint256(A ^ B) < uint256(2**(256 - minimum));
+        return uint256(A ^ B) < uint256(2 ** (256 - minimum));
     }
 
     /**
@@ -379,12 +367,7 @@ contract Redistribution is AccessControl, Pausable {
      * @param _hash The reserve commitment hash.
      * @param _revealNonce The nonce used to generate the commit that is being revealed.
      */
-    function reveal(
-        bytes32 _overlay,
-        uint8 _depth,
-        bytes32 _hash,
-        bytes32 _revealNonce
-    ) external whenNotPaused {
+    function reveal(bytes32 _overlay, uint8 _depth, bytes32 _hash, bytes32 _revealNonce) external whenNotPaused {
         require(currentPhaseReveal(), "not in reveal phase");
 
         uint256 cr = currentRound();
@@ -417,7 +400,7 @@ contract Redistribution is AccessControl, Pausable {
                         owner: currentCommits[i].owner,
                         overlay: currentCommits[i].overlay,
                         stake: currentCommits[i].stake,
-                        stakeDensity: currentCommits[i].stake * uint256(2**_depth),
+                        stakeDensity: currentCommits[i].stake * uint256(2 ** _depth),
                         hash: _hash,
                         depth: _depth
                     })
@@ -427,7 +410,7 @@ contract Redistribution is AccessControl, Pausable {
                     cr,
                     currentCommits[i].overlay,
                     currentCommits[i].stake,
-                    currentCommits[i].stake * uint256(2**_depth),
+                    currentCommits[i].stake * uint256(2 ** _depth),
                     _hash,
                     _depth
                 );
@@ -647,7 +630,7 @@ contract Redistribution is AccessControl, Pausable {
                 } else {
                     Stakes.freezeDeposit(
                         currentReveals[revIndex].overlay,
-                        penaltyMultiplierDisagreement * roundLength * uint256(2**truthRevealedDepth)
+                        penaltyMultiplierDisagreement * roundLength * uint256(2 ** truthRevealedDepth)
                     );
                     // slash ph5
                 }
@@ -656,7 +639,7 @@ contract Redistribution is AccessControl, Pausable {
                 // Stakes.slashDeposit(currentCommits[i].overlay, currentCommits[i].stake);
                 Stakes.freezeDeposit(
                     currentCommits[i].overlay,
-                    penaltyMultiplierNonRevealed * roundLength * uint256(2**truthRevealedDepth)
+                    penaltyMultiplierNonRevealed * roundLength * uint256(2 ** truthRevealedDepth)
                 );
                 continue;
             }

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -641,7 +641,6 @@ contract Redistribution is AccessControl, Pausable {
                     currentCommits[i].overlay,
                     penaltyMultiplierNonRevealed * roundLength * uint256(2 ** truthRevealedDepth)
                 );
-                continue;
             }
         }
 

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -592,8 +592,6 @@ contract Redistribution is AccessControl, Pausable {
             }
         }
 
-        emit TruthSelected(truthRevealedHash, truthRevealedDepth);
-
         uint256 k = 0;
 
         string memory winnerSelectionAnchor = currentWinnerSelectionAnchor();
@@ -636,6 +634,7 @@ contract Redistribution is AccessControl, Pausable {
         }
 
         emit CountCommitsReveals(commitsArrayLength, revealsArrayLength);
+        emit TruthSelected(truthRevealedHash, truthRevealedDepth);
         emit WinnerSelected(winner);
 
         PostageContract.withdraw(winner.owner);

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -164,7 +164,7 @@ contract Redistribution is AccessControl, Pausable {
     /**
      * @dev Emits the number of commits and reveals being processed by the claim phase.
      */
-    event CountCommitsReveals(uint256 _count, uint256 _count2);
+    event CountCommitsReveals(uint256 countCommits, uint256 countReveals);
 
     /**
      * @dev Logs that an overlay has committed
@@ -430,6 +430,7 @@ contract Redistribution is AccessControl, Pausable {
         uint256 currentWinnerSelectionSum;
         bytes32 winnerIs;
         bytes32 randomNumber;
+        uint256 randomNumberTrunc;
         bytes32 truthRevealedHash;
         uint8 truthRevealedDepth;
         uint256 revIndex;
@@ -441,6 +442,8 @@ contract Redistribution is AccessControl, Pausable {
 
         for (uint256 i = 0; i < currentCommits.length; i++) {
             revIndex = currentCommits[i].revealIndex;
+
+            // Deterministically read winner
             if (
                 currentCommits[i].revealed &&
                 truthRevealedHash == currentReveals[revIndex].hash &&
@@ -448,9 +451,10 @@ contract Redistribution is AccessControl, Pausable {
             ) {
                 currentWinnerSelectionSum += currentReveals[revIndex].stakeDensity;
                 randomNumber = keccak256(abi.encodePacked(winnerSelectionAnchor, k));
+                randomNumberTrunc = uint256(randomNumber & MaxH);
 
                 if (
-                    uint256(randomNumber & MaxH) * currentWinnerSelectionSum <
+                    randomNumberTrunc * currentWinnerSelectionSum <
                     currentReveals[revIndex].stakeDensity * (uint256(MaxH) + 1)
                 ) {
                     winnerIs = currentReveals[revIndex].overlay;

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -423,9 +423,7 @@ contract Redistribution is AccessControl, Pausable {
      */
     function isWinner(bytes32 _overlay) public view returns (bool) {
         require(currentPhaseClaim(), "winner not determined yet");
-
         uint256 cr = currentRound();
-
         require(cr == currentRevealRound, "round received no reveals");
         require(cr > currentClaimRound, "round already received successful claim");
 
@@ -435,13 +433,11 @@ contract Redistribution is AccessControl, Pausable {
         bytes32 truthRevealedHash;
         uint8 truthRevealedDepth;
         uint256 revIndex;
+        string memory winnerSelectionAnchor = currentWinnerSelectionAnchor();
+        uint256 k = 0;
 
         // Get current truth
         (truthRevealedHash, truthRevealedDepth) = getCurrentTruth();
-
-        uint256 k = 0;
-
-        string memory winnerSelectionAnchor = currentWinnerSelectionAnchor();
 
         for (uint256 i = 0; i < currentCommits.length; i++) {
             revIndex = currentCommits[i].revealIndex;
@@ -543,7 +539,6 @@ contract Redistribution is AccessControl, Pausable {
                 revIndex = currentCommits[i].revealIndex;
                 currentSum += currentReveals[revIndex].stakeDensity;
                 randomNumber = keccak256(abi.encodePacked(truthSelectionAnchor, i));
-
                 randomNumberTrunc = uint256(randomNumber & MaxH);
 
                 // question is whether randomNumber / MaxH < probability
@@ -569,25 +564,21 @@ contract Redistribution is AccessControl, Pausable {
      */
     function claim() external whenNotPaused {
         require(currentPhaseClaim(), "not in claim phase");
-
         uint256 cr = currentRound();
-
         require(cr == currentRevealRound, "round received no reveals");
         require(cr > currentClaimRound, "round already received successful claim");
 
         uint256 currentWinnerSelectionSum;
         bytes32 randomNumber;
         uint256 randomNumberTrunc;
-
         bytes32 truthRevealedHash;
         uint8 truthRevealedDepth;
         uint256 revIndex;
+        string memory winnerSelectionAnchor = currentWinnerSelectionAnchor();
+        uint256 k = 0;
 
         // Get current truth
         (truthRevealedHash, truthRevealedDepth) = getCurrentTruth();
-
-        uint256 k = 0;
-        string memory winnerSelectionAnchor = currentWinnerSelectionAnchor();
 
         for (uint256 i = 0; i < currentCommits.length; i++) {
             revIndex = currentCommits[i].revealIndex;

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -162,9 +162,14 @@ contract Redistribution is AccessControl, Pausable {
 
     // Next two events to be removed after testing phase pending some other usefulness being found.
     /**
-     * @dev Emits the number of commits and reveals being processed by the claim phase.
+     * @dev Emits the number of commits being processed by the claim phase.
      */
-    event CountCommitsReveals(uint256 countCommits, uint256 countReveals);
+    event CountCommits(uint256 _count);
+
+    /**
+     * @dev Emits the number of reveals being processed by the claim phase.
+     */
+    event CountReveals(uint256 _count);
 
     /**
      * @dev Logs that an overlay has committed
@@ -635,7 +640,8 @@ contract Redistribution is AccessControl, Pausable {
         }
 
         // Emit function Events
-        emit CountCommitsReveals(commitsArrayLength, revealsArrayLength);
+        emit CountCommits(commitsArrayLength);
+        emit CountReveals(revealsArrayLength);
         emit TruthSelected(truthRevealedHash, truthRevealedDepth);
         emit WinnerSelected(winner);
 

--- a/test/Redistribution.test.ts
+++ b/test/Redistribution.test.ts
@@ -613,7 +613,7 @@ describe('Redistribution', function () {
           const tx2 = await r_node_2.claim();
           const receipt2 = await tx2.wait();
 
-          let WinnerSelectedEvent, TruthSelectedEvent, CountCommitsRevealsEvent;
+          let WinnerSelectedEvent, TruthSelectedEvent, CountCommitsEvent, CountRevealsEvent;
           for (const e of receipt2.events) {
             if (e.event == 'WinnerSelected') {
               WinnerSelectedEvent = e;
@@ -621,8 +621,11 @@ describe('Redistribution', function () {
             if (e.event == 'TruthSelected') {
               TruthSelectedEvent = e;
             }
-            if (e.event == 'CountCommitsReveals') {
-              CountCommitsRevealsEvent = e;
+            if (e.event == 'CountCommits') {
+              CountCommitsEvent = e;
+            }
+            if (e.event == 'CountReveals') {
+              CountRevealsEvent = e;
             }
           }
 
@@ -631,8 +634,8 @@ describe('Redistribution', function () {
 
           expect(await token.balanceOf(node_2)).to.be.eq(expectedPotPayout);
 
-          expect(CountCommitsRevealsEvent.args[0]).to.be.eq(1);
-          expect(CountCommitsRevealsEvent.args[1]).to.be.eq(1);
+          expect(CountCommitsEvent.args[0]).to.be.eq(1);
+          expect(CountRevealsEvent.args[0]).to.be.eq(1);
 
           expect(WinnerSelectedEvent.args[0][0]).to.be.eq(node_2);
           expect(WinnerSelectedEvent.args[0][1]).to.be.eq(overlay_2);
@@ -687,7 +690,7 @@ describe('Redistribution', function () {
           const tx2 = await r_node_2.claim();
           const receipt2 = await tx2.wait();
 
-          let WinnerSelectedEvent, TruthSelectedEvent, CountCommitsRevealsEvent;
+          let WinnerSelectedEvent, TruthSelectedEvent, CountCommitsEvent, CountRevealsEvent;
           for (const e of receipt2.events) {
             if (e.event == 'WinnerSelected') {
               WinnerSelectedEvent = e;
@@ -695,8 +698,11 @@ describe('Redistribution', function () {
             if (e.event == 'TruthSelected') {
               TruthSelectedEvent = e;
             }
-            if (e.event == 'CountCommitsReveals') {
-              CountCommitsRevealsEvent = e;
+            if (e.event == 'CountCommits') {
+              CountCommitsEvent = e;
+            }
+            if (e.event == 'CountReveals') {
+              CountRevealsEvent = e;
             }
           }
 
@@ -708,8 +714,8 @@ describe('Redistribution', function () {
 
           expect(await token.balanceOf(node_2)).to.be.eq(expectedPotPayout);
 
-          expect(CountCommitsRevealsEvent.args[0]).to.be.eq(2);
-          expect(CountCommitsRevealsEvent.args[1]).to.be.eq(1);
+          expect(CountCommitsEvent.args[0]).to.be.eq(2);
+          expect(CountRevealsEvent.args[0]).to.be.eq(1);
 
           expect(WinnerSelectedEvent.args[0][0]).to.be.eq(node_2);
           expect(WinnerSelectedEvent.args[0][1]).to.be.eq(overlay_2);
@@ -750,7 +756,7 @@ describe('Redistribution', function () {
           const tx2 = await r_node_2.claim();
           const receipt2 = await tx2.wait();
 
-          let WinnerSelectedEvent, TruthSelectedEvent, CountCommitsRevealsEvent;
+          let WinnerSelectedEvent, TruthSelectedEvent, CountCommitsEvent, CountRevealsEvent;
           for (const e of receipt2.events) {
             if (e.event == 'WinnerSelected') {
               WinnerSelectedEvent = e;
@@ -758,8 +764,11 @@ describe('Redistribution', function () {
             if (e.event == 'TruthSelected') {
               TruthSelectedEvent = e;
             }
-            if (e.event == 'CountCommitsReveals') {
-              CountCommitsRevealsEvent = e;
+            if (e.event == 'CountCommits') {
+              CountCommitsEvent = e;
+            }
+            if (e.event == 'CountReveals') {
+              CountRevealsEvent = e;
             }
           }
 
@@ -768,8 +777,8 @@ describe('Redistribution', function () {
 
           expect(await token.balanceOf(node_1)).to.be.eq(expectedPotPayout);
 
-          expect(CountCommitsRevealsEvent.args[0]).to.be.eq(2);
-          expect(CountCommitsRevealsEvent.args[1]).to.be.eq(2);
+          expect(CountCommitsEvent.args[0]).to.be.eq(2);
+          expect(CountRevealsEvent.args[0]).to.be.eq(2);
 
           expect(WinnerSelectedEvent.args[0][0]).to.be.eq(node_1);
           expect(WinnerSelectedEvent.args[0][1]).to.be.eq(overlay_1);

--- a/test/Redistribution.test.ts
+++ b/test/Redistribution.test.ts
@@ -613,7 +613,7 @@ describe('Redistribution', function () {
           const tx2 = await r_node_2.claim();
           const receipt2 = await tx2.wait();
 
-          let WinnerSelectedEvent, TruthSelectedEvent, CountCommitsEvent, CountRevealsEvent;
+          let WinnerSelectedEvent, TruthSelectedEvent, CountCommitsRevealsEvent;
           for (const e of receipt2.events) {
             if (e.event == 'WinnerSelected') {
               WinnerSelectedEvent = e;
@@ -621,11 +621,8 @@ describe('Redistribution', function () {
             if (e.event == 'TruthSelected') {
               TruthSelectedEvent = e;
             }
-            if (e.event == 'CountCommits') {
-              CountCommitsEvent = e;
-            }
-            if (e.event == 'CountReveals') {
-              CountRevealsEvent = e;
+            if (e.event == 'CountCommitsReveals') {
+              CountCommitsRevealsEvent = e;
             }
           }
 
@@ -634,8 +631,8 @@ describe('Redistribution', function () {
 
           expect(await token.balanceOf(node_2)).to.be.eq(expectedPotPayout);
 
-          expect(CountCommitsEvent.args[0]).to.be.eq(1);
-          expect(CountRevealsEvent.args[0]).to.be.eq(1);
+          expect(CountCommitsRevealsEvent.args[0]).to.be.eq(2);
+          expect(CountCommitsRevealsEvent.args[1]).to.be.eq(1);
 
           expect(WinnerSelectedEvent.args[0][0]).to.be.eq(node_2);
           expect(WinnerSelectedEvent.args[0][1]).to.be.eq(overlay_2);
@@ -690,7 +687,7 @@ describe('Redistribution', function () {
           const tx2 = await r_node_2.claim();
           const receipt2 = await tx2.wait();
 
-          let WinnerSelectedEvent, TruthSelectedEvent, CountCommitsEvent, CountRevealsEvent;
+          let WinnerSelectedEvent, TruthSelectedEvent, CountCommitsRevealsEvent;
           for (const e of receipt2.events) {
             if (e.event == 'WinnerSelected') {
               WinnerSelectedEvent = e;
@@ -698,11 +695,8 @@ describe('Redistribution', function () {
             if (e.event == 'TruthSelected') {
               TruthSelectedEvent = e;
             }
-            if (e.event == 'CountCommits') {
-              CountCommitsEvent = e;
-            }
-            if (e.event == 'CountReveals') {
-              CountRevealsEvent = e;
+            if (e.event == 'CountCommitsReveals') {
+              CountCommitsRevealsEvent = e;
             }
           }
 
@@ -714,8 +708,8 @@ describe('Redistribution', function () {
 
           expect(await token.balanceOf(node_2)).to.be.eq(expectedPotPayout);
 
-          expect(CountCommitsEvent.args[0]).to.be.eq(2);
-          expect(CountRevealsEvent.args[0]).to.be.eq(1);
+          expect(CountCommitsRevealsEvent.args[0]).to.be.eq(2);
+          expect(CountCommitsRevealsEvent.args[1]).to.be.eq(1);
 
           expect(WinnerSelectedEvent.args[0][0]).to.be.eq(node_2);
           expect(WinnerSelectedEvent.args[0][1]).to.be.eq(overlay_2);
@@ -756,7 +750,7 @@ describe('Redistribution', function () {
           const tx2 = await r_node_2.claim();
           const receipt2 = await tx2.wait();
 
-          let WinnerSelectedEvent, TruthSelectedEvent, CountCommitsEvent, CountRevealsEvent;
+          let WinnerSelectedEvent, TruthSelectedEvent, CountCommitsRevealsEvent;
           for (const e of receipt2.events) {
             if (e.event == 'WinnerSelected') {
               WinnerSelectedEvent = e;
@@ -764,11 +758,8 @@ describe('Redistribution', function () {
             if (e.event == 'TruthSelected') {
               TruthSelectedEvent = e;
             }
-            if (e.event == 'CountCommits') {
-              CountCommitsEvent = e;
-            }
-            if (e.event == 'CountReveals') {
-              CountRevealsEvent = e;
+            if (e.event == 'CountCommitsReveals') {
+              CountCommitsRevealsEvent = e;
             }
           }
 
@@ -777,8 +768,8 @@ describe('Redistribution', function () {
 
           expect(await token.balanceOf(node_1)).to.be.eq(expectedPotPayout);
 
-          expect(CountCommitsEvent.args[0]).to.be.eq(2);
-          expect(CountRevealsEvent.args[0]).to.be.eq(2);
+          expect(CountCommitsRevealsEvent.args[0]).to.be.eq(2);
+          expect(CountCommitsRevealsEvent.args[1]).to.be.eq(1);
 
           expect(WinnerSelectedEvent.args[0][0]).to.be.eq(node_1);
           expect(WinnerSelectedEvent.args[0][1]).to.be.eq(overlay_1);

--- a/test/Redistribution.test.ts
+++ b/test/Redistribution.test.ts
@@ -631,7 +631,7 @@ describe('Redistribution', function () {
 
           expect(await token.balanceOf(node_2)).to.be.eq(expectedPotPayout);
 
-          expect(CountCommitsRevealsEvent.args[0]).to.be.eq(2);
+          expect(CountCommitsRevealsEvent.args[0]).to.be.eq(1);
           expect(CountCommitsRevealsEvent.args[1]).to.be.eq(1);
 
           expect(WinnerSelectedEvent.args[0][0]).to.be.eq(node_2);
@@ -769,7 +769,7 @@ describe('Redistribution', function () {
           expect(await token.balanceOf(node_1)).to.be.eq(expectedPotPayout);
 
           expect(CountCommitsRevealsEvent.args[0]).to.be.eq(2);
-          expect(CountCommitsRevealsEvent.args[1]).to.be.eq(1);
+          expect(CountCommitsRevealsEvent.args[1]).to.be.eq(2);
 
           expect(WinnerSelectedEvent.args[0][0]).to.be.eq(node_1);
           expect(WinnerSelectedEvent.args[0][1]).to.be.eq(overlay_1);

--- a/test/Stats.test.ts
+++ b/test/Stats.test.ts
@@ -1,5 +1,5 @@
 import { expect } from './util/chai';
-import { ethers, getNamedAccounts, getUnnamedAccounts } from 'hardhat';
+import { ethers, getNamedAccounts, getUnnamedAccounts, deployments } from 'hardhat';
 import { mineNBlocks, encodeAndHash, mintAndApprove, createOverlay } from './util/tools';
 
 const phaseLength = 38;
@@ -118,6 +118,9 @@ async function nPlayerGames(nodes: string[], stakes: string[], trials: number) {
 }
 
 describe('Stats', async function () {
+  beforeEach(async function () {
+    await deployments.fixture();
+  });
   describe('two player game', async function () {
     const trials = 150;
 


### PR DESCRIPTION
This task is mainly about cleaning the code to make it more readable and conscience. 
- Purpose of that is that it helps to read and understand code which in the end helps make fewer errors which is paramount when working with solidity
- I made pretty clear changes per each commit to what is going on so I suggest following it like that for CR
- Main change was focused on the claim function making it more readable by changing complex if/else structures which are really not a good way to code https://softwareengineering.stackexchange.com/questions/206816/clarification-of-avoid-if-else-advice
- Synched up the claim and isWinner function to have the same code
- I also changed some vars grouping 
- In the end, improved Stats test group for a better setup
- Also helped me get more accustomed with codebase


I also wanted to make claim/isWinner more reusable and reuse code as they share most of the code. But there is a big problem as one changes state and the other doesn't, so I couldn't find a proper way to refactor this unless I change the type of isWinner to write.