### PR TITLE
fix: add new redis events

### DIFF
--- a/scripts/deploy_redis.ts
+++ b/scripts/deploy_redis.ts
@@ -1,0 +1,29 @@
+import 'hardhat-deploy-ethers';
+import { ethers, network } from 'hardhat';
+import verify from '../utils/verify';
+
+async function main() {
+
+    if (network.name == 'testnet' || network.name == 'sepolia') {
+        // Staking, Stamps, Oracle
+        const args = ['0xCb07bf0603da228C8ec602bf12b973b8A94f9bac', '0x1f87FEDa43e6ABFe1058E96A07d0ea182e7dc9BD', '0x3e475aEAB162E28fee46E69225af446D3c4f3Bd3'];
+        const redisFactory = await ethers.getContractFactory("Redistribution");
+        console.log("Deploying contract...");
+        const redis = await redisFactory.deploy(...args);
+        await redis.deployed()
+        console.log(`Deployed contract to: ${redis.address}`);
+        await redis.deployTransaction.wait(6)
+
+        if (network.name == 'testnet' || network.name == 'sepolia') {
+            console.log('Verifying...');
+            await verify(redis.address, args);
+        }
+    }
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -2,9 +2,35 @@
 pragma solidity ^0.8.1;
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
-import "./PostageStamp.sol";
-import "./PriceOracle.sol";
-import "./Staking.sol";
+
+/**
+ * Implement interfaces to PostageStamp contract, PriceOracle contract and Staking contract.
+ * For PostageStmap we currently use "withdraw" to withdraw funds from Pot
+ * For PriceOracle we use "adjustPrice" to change price of PostageStamps
+ * For Staking contract we use "lastUpdatedBlockNumberOfOverlay, freezeDeposit, ownerOfOverlay, stakeOfOverlay"
+ */
+
+interface IPostageStamp {
+    function withdraw(address beneficiary) external;
+
+    function validChunkCount() external view returns (uint256);
+
+    function pot() external view returns (uint256);
+}
+
+interface IPriceOracle {
+    function adjustPrice(uint256 redundancy) external;
+}
+
+interface IStakeRegistry {
+    function lastUpdatedBlockNumberOfOverlay(bytes32 overlay) external view returns (uint256);
+
+    function freezeDeposit(bytes32 overlay, uint256 time) external;
+
+    function ownerOfOverlay(bytes32 overlay) external view returns (address);
+
+    function stakeOfOverlay(bytes32 overlay) external view returns (uint256);
+}
 
 /**
  * @title Redistribution contract
@@ -34,6 +60,7 @@ import "./Staking.sol";
  * is withdrawn and transferred to that beneficiaries address. Nodes that have revealed values that differ from the truth,
  * have their stakes "frozen" for a period of rounds proportional to their reported depth.
  */
+
 contract Redistribution is AccessControl, Pausable {
     // An eligible user may commit to an _obfuscatedHash_ during the commit phase...
     struct Commit {
@@ -56,11 +83,11 @@ contract Redistribution is AccessControl, Pausable {
     }
 
     // The address of the linked PostageStamp contract.
-    PostageStamp public PostageContract;
+    IPostageStamp public PostageContract;
     // The address of the linked PriceOracle contract.
-    PriceOracle public OracleContract;
+    IPriceOracle public OracleContract;
     // The address of the linked Staking contract.
-    StakeRegistry public Stakes;
+    IStakeRegistry public Stakes;
 
     // Commits for the current round.
     Commit[] public currentCommits;
@@ -119,14 +146,10 @@ contract Redistribution is AccessControl, Pausable {
      * @param postageContract the address of the linked PostageStamp contract.
      * @param oracleContract the address of the linked PriceOracle contract.
      */
-    constructor(
-        address staking,
-        address postageContract,
-        address oracleContract
-    ) {
-        Stakes = StakeRegistry(staking);
-        PostageContract = PostageStamp(postageContract);
-        OracleContract = PriceOracle(oracleContract);
+    constructor(address staking, address postageContract, address oracleContract) {
+        Stakes = IStakeRegistry(staking);
+        PostageContract = IPostageStamp(postageContract);
+        OracleContract = IPriceOracle(oracleContract);
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _setupRole(PAUSER_ROLE, msg.sender);
     }
@@ -134,7 +157,7 @@ contract Redistribution is AccessControl, Pausable {
     /**
      * @dev Emitted when the winner of a round is selected in the claim phase.
      */
-    event WinnerSelected(Reveal winner);
+    event WinnerSelected(Reveal winner, uint256 roundNumber);
 
     /**
      * @dev Emitted when the truth oracle of a round is selected in the claim phase.
@@ -156,6 +179,16 @@ contract Redistribution is AccessControl, Pausable {
      * @dev Logs that an overlay has committed
      */
     event Committed(uint256 roundNumber, bytes32 overlay);
+
+    /**
+     * @dev Postagestamp contract current status of important values
+     */
+    event PostageStampStatus(uint256 validChunkCount, uint256 pot);
+
+    /**
+     * @dev Bytes32 anhor of current reveal round
+     */
+    event CurrentRevealAnchor(uint256 roundNumber, bytes32 anchor);
 
     /**
      * @dev Logs that an overlay has revealed
@@ -191,7 +224,7 @@ contract Redistribution is AccessControl, Pausable {
      */
     function currentPhaseReveal() public view returns (bool) {
         uint256 number = block.number % roundLength;
-        if ( number >= roundLength / 4 && number < roundLength / 2 ) {
+        if (number >= roundLength / 4 && number < roundLength / 2) {
             return true;
         }
         return false;
@@ -200,8 +233,8 @@ contract Redistribution is AccessControl, Pausable {
     /**
      * @notice Returns true if current block is during claim phase.
      */
-    function currentPhaseClaim() public view returns (bool){
-        if ( block.number % roundLength >= roundLength / 2 ) {
+    function currentPhaseClaim() public view returns (bool) {
+        if (block.number % roundLength >= roundLength / 2) {
             return true;
         }
         return false;
@@ -227,13 +260,9 @@ contract Redistribution is AccessControl, Pausable {
      * @param _overlay The overlay referenced in the pre-image. Must be staked by at least the minimum value,
      * and be derived from the same key pair as the message sender.
      */
-    function commit(
-        bytes32 _obfuscatedHash,
-        bytes32 _overlay,
-        uint256 _roundNumber
-    ) external whenNotPaused {
+    function commit(bytes32 _obfuscatedHash, bytes32 _overlay, uint256 _roundNumber) external whenNotPaused {
         require(currentPhaseCommit(), "not in commit phase");
-        require( block.number % roundLength != ( roundLength / 4 ) - 1, "can not commit in last block of phase");
+        require(block.number % roundLength != (roundLength / 4) - 1, "can not commit in last block of phase");
         uint256 cr = currentRound();
         require(cr <= _roundNumber, "commit round over");
         require(cr >= _roundNumber, "commit round not started yet");
@@ -315,25 +344,17 @@ contract Redistribution is AccessControl, Pausable {
         seed = keccak256(abi.encode(seed, block.difficulty));
     }
 
-    function nonceBasedRandomness(bytes32 nonce) private {
-        seed = seed ^ nonce;
-    }
-
     /**
      * @notice Returns true if an overlay address _A_ is within proximity order _minimum_ of _B_.
      * @param A An overlay address to compare.
      * @param B An overlay address to compare.
      * @param minimum Minimum proximity order.
      */
-    function inProximity(
-        bytes32 A,
-        bytes32 B,
-        uint8 minimum
-    ) public pure returns (bool) {
+    function inProximity(bytes32 A, bytes32 B, uint8 minimum) public pure returns (bool) {
         if (minimum == 0) {
             return true;
         }
-        return uint256(A ^ B) < uint256(2**(256 - minimum));
+        return uint256(A ^ B) < uint256(2 ** (256 - minimum));
     }
 
     /**
@@ -360,22 +381,21 @@ contract Redistribution is AccessControl, Pausable {
      * @param _hash The reserve commitment hash.
      * @param _revealNonce The nonce used to generate the commit that is being revealed.
      */
-    function reveal(
-        bytes32 _overlay,
-        uint8 _depth,
-        bytes32 _hash,
-        bytes32 _revealNonce
-    ) external whenNotPaused {
+    function reveal(bytes32 _overlay, uint8 _depth, bytes32 _hash, bytes32 _revealNonce) external whenNotPaused {
         require(currentPhaseReveal(), "not in reveal phase");
 
         uint256 cr = currentRound();
 
+        // Check status of commit phase
         require(cr == currentCommitRound, "round received no commits");
+
+        // Set state for new reveal round on first reveal
         if (cr != currentRevealRound) {
             currentRevealRoundAnchor = currentRoundAnchor();
             delete currentReveals;
             currentRevealRound = cr;
             updateRandomness();
+            emit CurrentRevealAnchor(cr, currentRevealRoundAnchor);
         }
 
         bytes32 commitHash = wrapCommit(_overlay, _depth, _hash, _revealNonce);
@@ -388,7 +408,7 @@ contract Redistribution is AccessControl, Pausable {
                     inProximity(currentCommits[i].overlay, currentRevealRoundAnchor, _depth),
                     "anchor out of self reported depth"
                 );
-                //check can only revealed once
+                // Check if overlay tried to reveal more then once
                 require(currentCommits[i].revealed == false, "participant already revealed");
                 currentCommits[i].revealed = true;
                 currentCommits[i].revealIndex = currentReveals.length;
@@ -398,19 +418,17 @@ contract Redistribution is AccessControl, Pausable {
                         owner: currentCommits[i].owner,
                         overlay: currentCommits[i].overlay,
                         stake: currentCommits[i].stake,
-                        stakeDensity: currentCommits[i].stake * uint256(2**_depth),
+                        stakeDensity: currentCommits[i].stake * uint256(2 ** _depth),
                         hash: _hash,
                         depth: _depth
                     })
                 );
 
-                nonceBasedRandomness(_revealNonce);
-
                 emit Revealed(
                     cr,
                     currentCommits[i].overlay,
                     currentCommits[i].stake,
-                    currentCommits[i].stake * uint256(2**_depth),
+                    currentCommits[i].stake * uint256(2 ** _depth),
                     _hash,
                     _depth
                 );
@@ -428,54 +446,40 @@ contract Redistribution is AccessControl, Pausable {
      */
     function isWinner(bytes32 _overlay) public view returns (bool) {
         require(currentPhaseClaim(), "winner not determined yet");
-
         uint256 cr = currentRound();
-
         require(cr == currentRevealRound, "round received no reveals");
         require(cr > currentClaimRound, "round already received successful claim");
 
-        string memory truthSelectionAnchor = currentTruthSelectionAnchor();
-
-        uint256 currentSum;
         uint256 currentWinnerSelectionSum;
         bytes32 winnerIs;
         bytes32 randomNumber;
-
+        uint256 randomNumberTrunc;
         bytes32 truthRevealedHash;
         uint8 truthRevealedDepth;
-
-        uint256 commitsArrayLength = currentCommits.length;
-
         uint256 revIndex;
+        string memory winnerSelectionAnchor = currentWinnerSelectionAnchor();
         uint256 k = 0;
 
-        for (uint256 i = 0; i < commitsArrayLength; i++) {
-            if (currentCommits[i].revealed) {
-                revIndex = currentCommits[i].revealIndex;
-                currentSum += currentReveals[revIndex].stakeDensity;
-                randomNumber = keccak256(abi.encodePacked(truthSelectionAnchor, k));
-
-                if (uint256(randomNumber & MaxH) * currentSum < currentReveals[revIndex].stakeDensity * (uint256(MaxH) + 1)) {
-                    truthRevealedHash = currentReveals[revIndex].hash;
-                    truthRevealedDepth = currentReveals[revIndex].depth;
-                }
-
-                k++;
-            }
-        }
-
-        k = 0;
-
-        string memory winnerSelectionAnchor = currentWinnerSelectionAnchor();
+        // Get current truth
+        (truthRevealedHash, truthRevealedDepth) = getCurrentTruth();
+        uint256 commitsArrayLength = currentCommits.length;
 
         for (uint256 i = 0; i < commitsArrayLength; i++) {
             revIndex = currentCommits[i].revealIndex;
-            if (currentCommits[i].revealed && truthRevealedHash == currentReveals[revIndex].hash && truthRevealedDepth == currentReveals[revIndex].depth) {
+
+            // Deterministically read winner
+            if (
+                currentCommits[i].revealed &&
+                truthRevealedHash == currentReveals[revIndex].hash &&
+                truthRevealedDepth == currentReveals[revIndex].depth
+            ) {
                 currentWinnerSelectionSum += currentReveals[revIndex].stakeDensity;
                 randomNumber = keccak256(abi.encodePacked(winnerSelectionAnchor, k));
+                randomNumberTrunc = uint256(randomNumber & MaxH);
 
                 if (
-                    uint256(randomNumber & MaxH) * currentWinnerSelectionSum < currentReveals[revIndex].stakeDensity * (uint256(MaxH) + 1)
+                    randomNumberTrunc * currentWinnerSelectionSum <
+                    currentReveals[revIndex].stakeDensity * (uint256(MaxH) + 1)
                 ) {
                     winnerIs = currentReveals[revIndex].overlay;
                 }
@@ -486,6 +490,7 @@ contract Redistribution is AccessControl, Pausable {
 
         return (winnerIs == _overlay);
     }
+
     /**
      * @notice Determine if a the owner of a given overlay can participate in the upcoming round.
      * @param overlay The overlay address of the applicant.
@@ -544,42 +549,25 @@ contract Redistribution is AccessControl, Pausable {
     }
 
     /**
-     * @notice Conclude the current round by identifying the selected truth teller and beneficiary.
+     * @notice Helper function to get this round truth
      * @dev
      */
-    function claim() external whenNotPaused {
-        require(currentPhaseClaim(), "not in claim phase");
-
-        uint256 cr = currentRound();
-
-        require(cr == currentRevealRound, "round received no reveals");
-        require(cr > currentClaimRound, "round already received successful claim");
-
-        string memory truthSelectionAnchor = currentTruthSelectionAnchor();
-
+    function getCurrentTruth() internal view returns (bytes32 Hash, uint8 Depth) {
         uint256 currentSum;
-        uint256 currentWinnerSelectionSum;
         bytes32 randomNumber;
         uint256 randomNumberTrunc;
 
         bytes32 truthRevealedHash;
         uint8 truthRevealedDepth;
-
-        uint256 commitsArrayLength = currentCommits.length;
-        uint256 revealsArrayLength = currentReveals.length;
-
-        emit CountCommits(commitsArrayLength);
-        emit CountReveals(revealsArrayLength);
-
         uint256 revIndex;
-        uint256 k = 0;
+        string memory truthSelectionAnchor = currentTruthSelectionAnchor();
+        uint256 commitsArrayLength = currentCommits.length;
 
         for (uint256 i = 0; i < commitsArrayLength; i++) {
             if (currentCommits[i].revealed) {
                 revIndex = currentCommits[i].revealIndex;
                 currentSum += currentReveals[revIndex].stakeDensity;
-                randomNumber = keccak256(abi.encodePacked(truthSelectionAnchor, k));
-
+                randomNumber = keccak256(abi.encodePacked(truthSelectionAnchor, i));
                 randomNumberTrunc = uint256(randomNumber & MaxH);
 
                 // question is whether randomNumber / MaxH < probability
@@ -593,51 +581,92 @@ contract Redistribution is AccessControl, Pausable {
                     truthRevealedHash = currentReveals[revIndex].hash;
                     truthRevealedDepth = currentReveals[revIndex].depth;
                 }
-
-                k++;
             }
         }
 
-        emit TruthSelected(truthRevealedHash, truthRevealedDepth);
+        return (truthRevealedHash, truthRevealedDepth);
+    }
 
-        k = 0;
+    /**
+     * @notice Conclude the current round by identifying the selected truth teller and beneficiary.
+     * @dev
+     */
+    function claim() external whenNotPaused {
+        require(currentPhaseClaim(), "not in claim phase");
+        uint256 cr = currentRound();
+        require(cr == currentRevealRound, "round received no reveals");
+        require(cr > currentClaimRound, "round already received successful claim");
 
+        uint256 currentWinnerSelectionSum;
+        bytes32 randomNumber;
+        uint256 randomNumberTrunc;
+        bytes32 truthRevealedHash;
+        uint8 truthRevealedDepth;
+        uint256 revIndex;
         string memory winnerSelectionAnchor = currentWinnerSelectionAnchor();
+        uint256 k = 0;
+
+        // Get current truth
+        (truthRevealedHash, truthRevealedDepth) = getCurrentTruth();
+        uint256 commitsArrayLength = currentCommits.length;
+        uint256 revealsArrayLength = currentReveals.length;
 
         for (uint256 i = 0; i < commitsArrayLength; i++) {
             revIndex = currentCommits[i].revealIndex;
-            if (currentCommits[i].revealed ) {
-               if ( truthRevealedHash == currentReveals[revIndex].hash && truthRevealedDepth == currentReveals[revIndex].depth) {
-                    currentWinnerSelectionSum += currentReveals[revIndex].stakeDensity;
-                    randomNumber = keccak256(abi.encodePacked(winnerSelectionAnchor, k));
 
-                    randomNumberTrunc = uint256(randomNumber & MaxH);
+            // Select winner with valid truth
+            if (
+                currentCommits[i].revealed &&
+                truthRevealedHash == currentReveals[revIndex].hash &&
+                truthRevealedDepth == currentReveals[revIndex].depth
+            ) {
+                currentWinnerSelectionSum += currentReveals[revIndex].stakeDensity;
+                randomNumber = keccak256(abi.encodePacked(winnerSelectionAnchor, k));
+                randomNumberTrunc = uint256(randomNumber & MaxH);
 
-                    if (
-                        randomNumberTrunc * currentWinnerSelectionSum < currentReveals[revIndex].stakeDensity * (uint256(MaxH) + 1)
-                    ) {
-                        winner = currentReveals[revIndex];
-                    }
-
-                    k++;
-                } else {
-                    Stakes.freezeDeposit(currentReveals[revIndex].overlay, penaltyMultiplierDisagreement * roundLength * uint256(2**truthRevealedDepth));
-                    // slash ph5
+                if (
+                    randomNumberTrunc * currentWinnerSelectionSum <
+                    currentReveals[revIndex].stakeDensity * (uint256(MaxH) + 1)
+                ) {
+                    winner = currentReveals[revIndex];
                 }
-            } else {
-                // slash in later phase
+
+                k++;
+            }
+
+            // Freeze deposit if any truth is false
+            if (
+                currentCommits[i].revealed &&
+                (truthRevealedHash != currentReveals[revIndex].hash ||
+                    truthRevealedDepth != currentReveals[revIndex].depth)
+            ) {
+                Stakes.freezeDeposit(
+                    currentReveals[revIndex].overlay,
+                    penaltyMultiplierDisagreement * roundLength * uint256(2 ** truthRevealedDepth)
+                );
+            }
+
+            // Slash deposits if revealed is false
+            if (!currentCommits[i].revealed) {
+                // slash in later phase (ph5)
                 // Stakes.slashDeposit(currentCommits[i].overlay, currentCommits[i].stake);
-                Stakes.freezeDeposit(currentCommits[i].overlay, penaltyMultiplierNonRevealed * roundLength * uint256(2**truthRevealedDepth));
-                continue;
+                Stakes.freezeDeposit(
+                    currentCommits[i].overlay,
+                    penaltyMultiplierNonRevealed * roundLength * uint256(2 ** truthRevealedDepth)
+                );
             }
         }
 
-        emit WinnerSelected(winner);
-
+        // Apply Important state changes
         PostageContract.withdraw(winner.owner);
-
         OracleContract.adjustPrice(uint256(k));
-
         currentClaimRound = cr;
+
+        // Emit function Events
+        emit CountCommits(commitsArrayLength);
+        emit CountReveals(revealsArrayLength);
+        emit TruthSelected(truthRevealedHash, truthRevealedDepth);
+        emit WinnerSelected(winner, cr);
+        emit PostageStampStatus(PostageContract.validChunkCount(), PostageContract.pot());
     }
 }

--- a/utils/verify.ts
+++ b/utils/verify.ts
@@ -1,0 +1,19 @@
+import { run } from 'hardhat';
+
+const verify = async (contractAddress: string, args: any[]) => {
+    console.log('Verifying contract...');
+    try {
+        await run('verify:verify', {
+            address: contractAddress,
+            constructorArguments: args,
+        });
+    } catch (e: any) {
+        if (e.message.toLowerCase().includes('already verified')) {
+            console.log('Already verified!');
+        } else {
+            console.log(e);
+        }
+    }
+};
+
+export default verify;


### PR DESCRIPTION
Ok, I did apply all the changes we have in the current master of redis as they are mostly cosmetic. 
All tests pass with the current version, old deployment scripts also work on this new version.

Important changes for this task are
- we already have round emitted for commit here so it's not needed to add
https://github.com/ethersphere/storage-incentives/blob/83d585bf0f6e1a6fb86b4266128d5392e5875e64/src/Redistribution.sol#L303
- line 398 https://github.com/ethersphere/storage-incentives/blob/83d585bf0f6e1a6fb86b4266128d5392e5875e64/src/Redistribution.sol#L398
where we emit current round and anchor
- line 669 https://github.com/ethersphere/storage-incentives/blob/83d585bf0f6e1a6fb86b4266128d5392e5875e64/src/Redistribution.sol#L669
where we add the current round to the winner event, so we can associate the winner with the winning round and/or just fetch the current round for this claim 
- line 670 https://github.com/ethersphere/storage-incentives/blob/83d585bf0f6e1a6fb86b4266128d5392e5875e64/src/Redistribution.sol#L670
where we now have validChunkCount added as an event, also added pot size, which could be useful but can remove

Additional note, there is also round number emmited for reveal in each reveal event
https://github.com/ethersphere/storage-incentives/blob/83d585bf0f6e1a6fb86b4266128d5392e5875e64/src/Redistribution.sol#L427
but as we need to emit anchor, it seemed ok to emit also round number there.

