### PR TITLE
fix: fixing wrong API

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -155,7 +155,7 @@ const config: HardhatUserConfig = {
         network: 'mainnet',
         chainId: 100,
         urls: {
-          apiURL: 'https://gnosisscan.io/apis',
+          apiURL: 'https://api.gnosisscan.io/',
           browserURL: 'https://gnosisscan.io/address/',
         },
       },


### PR DESCRIPTION
This API endpoint for Gnosis is wrong, this one is proper 
https://docs.gnosisscan.io/getting-started/endpoint-urls