### PR TITLE
fix: put proper Swarm network ID

### DIFF
--- a/deploy/006_deploy_local_data.ts
+++ b/deploy/006_deploy_local_data.ts
@@ -1,5 +1,5 @@
 import { DeployFunction } from 'hardhat-deploy/types';
-import { developmentChains, deployedBzzData } from '../helper-hardhat-config';
+import { developmentChains, deployedBzzData, networkConfig } from '../helper-hardhat-config';
 import * as fs from 'fs';
 
 interface DeployedContract {
@@ -27,7 +27,8 @@ const func: DeployFunction = async function ({ deployments, network }) {
 
   const deployedData = {
     chainId: network.config.chainId,
-    swarmNetworkId: networkConfig[network.name]?.swarmNetworkId  ? networkConfig[network.name]?.swarmNetworkId : 1,
+
+    swarmNetworkId: networkConfig[network.name]?.swarmNetworkId ? networkConfig[network.name]?.swarmNetworkId : 1,
     contracts: {
       bzzToken: {} as DeployedContract,
       staking: {} as DeployedContract,

--- a/deploy/006_deploy_local_data.ts
+++ b/deploy/006_deploy_local_data.ts
@@ -27,8 +27,7 @@ const func: DeployFunction = async function ({ deployments, network }) {
 
   const deployedData = {
     chainId: network.config.chainId,
-
-    swarmNetworkId: networkConfig[network.name]?.swarmNetworkId ? networkConfig[network.name]?.swarmNetworkId : 1,
+    swarmNetworkId: networkConfig[network.name]?.swarmNetworkId || 1,
     contracts: {
       bzzToken: {} as DeployedContract,
       staking: {} as DeployedContract,

--- a/deploy/006_deploy_local_data.ts
+++ b/deploy/006_deploy_local_data.ts
@@ -12,7 +12,7 @@ interface DeployedContract {
 
 interface DeployedData {
   chainId: number;
-  networkId: number;
+  swarmNetworkId: number;
   contracts: {
     postageStamp: DeployedContract;
     redistribution: DeployedContract;
@@ -25,10 +25,9 @@ interface DeployedData {
 const func: DeployFunction = async function ({ deployments, network }) {
   const { get, log } = deployments;
 
-  // Chain ID and Network ID are often the same but could be different https://chainid.network/chains_mini.json
   const deployedData = {
     chainId: network.config.chainId,
-    networkId: network.config.chainId,
+    swarmNetworkId: networkConfig[network.name]?.swarmNetworkId  ? networkConfig[network.name]?.swarmNetworkId : 1,
     contracts: {
       bzzToken: {} as DeployedContract,
       staking: {} as DeployedContract,

--- a/deploy/007_deploy_verify.ts
+++ b/deploy/007_deploy_verify.ts
@@ -1,10 +1,9 @@
 import { DeployFunction } from 'hardhat-deploy/types';
-import { developmentChains, deployedBzzData } from '../helper-hardhat-config';
+import { deployedBzzData } from '../helper-hardhat-config';
 import verify from '../utils/verify';
 
 const func: DeployFunction = async function ({ deployments, network, ethers }) {
   const { log, get } = deployments;
-
 
   if ((network.name == 'mainnet' || network.name == 'testnet') && process.env.MAINNET_ETHERSCAN_KEY) {
     // contract veryfing vars

--- a/helper-hardhat-config.ts
+++ b/helper-hardhat-config.ts
@@ -2,6 +2,7 @@
 
 export interface networkConfigItem {
   blockConfirmations?: number;
+  swarmNetworkId?:number;
 }
 
 export interface networkConfigInfo {
@@ -13,9 +14,11 @@ export const networkConfig: networkConfigInfo = {
   hardhat: {},
   testnet: {
     blockConfirmations: 6,
+    swarmNetworkId: 10,
   },
   mainnet: {
     blockConfirmations: 6,
+    swarmNetworkId: 1,
   },
 };
 

--- a/helper-hardhat-config.ts
+++ b/helper-hardhat-config.ts
@@ -2,7 +2,7 @@
 
 export interface networkConfigItem {
   blockConfirmations?: number;
-  swarmNetworkId?:number;
+  swarmNetworkId?: number;
 }
 
 export interface networkConfigInfo {

--- a/mainnet_deployed.json
+++ b/mainnet_deployed.json
@@ -1,6 +1,6 @@
 {
 	"chainId": 100,
-	"networkId": 100,
+	"networkId": 1,
 	"contracts": {
 		"bzzToken": {
 			"abi": [

--- a/testnet_deployed.json
+++ b/testnet_deployed.json
@@ -1,6 +1,6 @@
 {
 	"chainId": 5,
-	"networkId": 5,
+	"swarmNetworkId": 10,
 	"contracts": {
 		"bzzToken": {
 			"abi": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,6 @@
     "outDir": "dist",
     "resolveJsonModule": true
   },
-  "include": ["hardhat.config.ts", "./scripts", "./deploy", "./test"]
+  "include": ["hardhat.config.ts", "./scripts", "./deploy", "./test", "./utils"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
 }


### PR DESCRIPTION
We were using the same network identifier for the swarm network as it is used for blockchain network, so we are changing it here so it's clear what we are referring to.