### PR TITLE
refactor:  Reveal flow

### DIFF
--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -5,7 +5,6 @@ import "@openzeppelin/contracts/security/Pausable.sol";
 import "./Util/TransformedChunkProof.sol";
 import "./Util/ChunkProof.sol";
 import "./Util/Signatures.sol";
-import "hardhat/console.sol";
 
 /**
  * Implement interfaces to PostageStamp contract, PriceOracle contract and Staking contract.
@@ -686,7 +685,6 @@ contract Redistribution is AccessControl, Pausable {
                 id = i;
             }
         }
-        console.log(id);
         return id;
     }
 

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -313,7 +313,6 @@ contract Redistribution is AccessControl, Pausable {
      * @param _hash The reserve commitment hash.
      * @param _revealNonce The nonce used to generate the commit that is being revealed.
      */
-
     function reveal(bytes32 _overlay, uint8 _depth, bytes32 _hash, bytes32 _revealNonce) external whenNotPaused {
         require(currentPhaseReveal(), "not in reveal phase");
 
@@ -331,8 +330,6 @@ contract Redistribution is AccessControl, Pausable {
         bytes32 commitHash = wrapCommit(_overlay, _depth, _hash, _revealNonce);
         uint256 id = findCommit(_overlay, commitHash, currentCommits.length);
 
-        // Check that the commit exists,
-        require(id != type(uint256).max, "no matching commit or hash");
         // Check that commit is in proximity of the current anchor
         require(
             inProximity(currentCommits[id].overlay, currentRevealRoundAnchor, _depth),
@@ -678,14 +675,13 @@ contract Redistribution is AccessControl, Pausable {
      * @notice Helper function to get this node reveal in commits
      * @dev
      */
-    function findCommit(bytes32 _overlay, bytes32 _commitHash, uint256 _length) internal view returns (uint256 id) {
-        id = type(uint256).max;
+    function findCommit(bytes32 _overlay, bytes32 _commitHash, uint256 _length) internal view returns (uint256) {
         for (uint256 i = 0; i < _length; i++) {
             if (currentCommits[i].overlay == _overlay && _commitHash == currentCommits[i].obfuscatedHash) {
-                id = i;
+                return i;
             }
         }
-        return id;
+        revert("No matching commit or hash.");
     }
 
     /**

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -681,7 +681,7 @@ contract Redistribution is AccessControl, Pausable {
                 return i;
             }
         }
-        revert("No matching commit or hash.");
+        revert("no matching commit or hash");
     }
 
     /**

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -330,7 +330,7 @@ contract Redistribution is AccessControl, Pausable {
         }
 
         bytes32 commitHash = wrapCommit(_overlay, _depth, _hash, _revealNonce);
-        uint256 id = findReveal(_overlay, commitHash, currentCommits.length);
+        uint256 id = findCommit(_overlay, commitHash, currentCommits.length);
 
         // Check that the commit exists,
         require(id != type(uint256).max, "no matching commit or hash");
@@ -363,17 +363,6 @@ contract Redistribution is AccessControl, Pausable {
             _hash,
             _depth
         );
-    }
-
-    function findReveal(bytes32 _overlay, bytes32 _commitHash, uint256 _length) internal view returns (uint256 id) {
-        id = type(uint256).max;
-        for (uint256 i = 0; i < _length; i++) {
-            if (currentCommits[i].overlay == _overlay && _commitHash == currentCommits[i].obfuscatedHash) {
-                id = i;
-            }
-        }
-        console.log(id);
-        return id;
     }
 
     /**
@@ -685,6 +674,21 @@ contract Redistribution is AccessControl, Pausable {
     }
 
     // ----------------------------- Reveal ------------------------------
+
+    /**
+     * @notice Helper function to get this node reveal in commits
+     * @dev
+     */
+    function findCommit(bytes32 _overlay, bytes32 _commitHash, uint256 _length) internal view returns (uint256 id) {
+        id = type(uint256).max;
+        for (uint256 i = 0; i < _length; i++) {
+            if (currentCommits[i].overlay == _overlay && _commitHash == currentCommits[i].obfuscatedHash) {
+                id = i;
+            }
+        }
+        console.log(id);
+        return id;
+    }
 
     /**
      * @notice Hash the pre-image values to the obsfucated hash.

--- a/test/Redistribution.test.ts
+++ b/test/Redistribution.test.ts
@@ -652,7 +652,6 @@ describe('Redistribution', function () {
           // anchor fixture
           await mineToNode(redistribution, 5);
           let currentSeed = await redistribution.currentSeed();
-          console.log('Anchor', currentSeed);
 
           expect(await redistribution.currentPhaseCommit()).to.be.true;
           const r_node_5 = await ethers.getContract('Redistribution', node_5);
@@ -672,7 +671,6 @@ describe('Redistribution', function () {
           await r_node_5.reveal(overlay_5, sanityDepth, sanityHash, reveal_nonce_2);
 
           currentSeed = await redistribution.currentSeed();
-          console.log('Anchor2', currentSeed);
 
           expect((await r_node_5.currentReveals(0)).hash).to.be.eq(sanityHash);
           expect((await r_node_5.currentReveals(0)).overlay).to.be.eq(overlay_5);


### PR DESCRIPTION
Make the flow of reveal nicer to read and follow, finding the commit in the array does not need to be a loop for all the code below, it can be just set to ID and then use in the flow of the reveal code.