### PR TITLE
fix: use same interface for both files

### DIFF
--- a/src/PriceOracle.sol
+++ b/src/PriceOracle.sol
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity ^0.8.19;
 import "@openzeppelin/contracts/access/AccessControl.sol";
-
-interface IPostageStamp {
-    function setPrice(uint256 _price) external;
-}
+import "./interface/IPostageStamp.sol";
 
 /**
  * @title PriceOracle contract.

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.19;
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
+import "./interface/IPostageStamp.sol";
 
 /**
  * Implement interfaces to PostageStamp contract, PriceOracle contract and Staking contract.
@@ -9,12 +10,6 @@ import "@openzeppelin/contracts/security/Pausable.sol";
  * For PriceOracle we use "adjustPrice" to change price of PostageStamps
  * For Staking contract we use "lastUpdatedBlockNumberOfOverlay, freezeDeposit, ownerOfOverlay, stakeOfOverlay"
  */
-
-interface IPostageStamp {
-    function withdraw(address beneficiary) external;
-
-    function validChunkCount() external view returns (uint256);
-}
 
 interface IPriceOracle {
     function adjustPrice(uint256 redundancy) external;

--- a/src/interface/IPostageStamp.sol
+++ b/src/interface/IPostageStamp.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.19;
+
+interface IPostageStamp {
+    function withdraw(address beneficiary) external;
+
+    function validChunkCount() external view returns (uint256);
+
+    function batchOwner(bytes32 _batchId) external view returns (address);
+
+    function batchDepth(bytes32 _batchId) external view returns (uint8);
+
+    function batchBucketDepth(bytes32 _batchId) external view returns (uint8);
+
+    function remainingBalance(bytes32 _batchId) external view returns (uint256);
+
+    function minimumInitialBalancePerChunk() external view returns (uint256);
+
+    function setPrice(uint256 _price) external;
+}


### PR DESCRIPTION
Using the same interface name in 2 places could lead to problems with codebase. Per slither analysis this is high vulnerability.