### PR TITLE
refactor: use old stamp methods

### DIFF
--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -946,9 +946,8 @@ contract Redistribution is AccessControl, Pausable {
     }
 
     function stampFunction(ChunkInclusionProof calldata entryProof) internal view {
+        (address batchOwner, uint8 batchDepth, uint8 bucketDepth, , ,) = PostageContract.batches(entryProof.postageProof.postageId);
         // authentic
-        uint8 batchDepth = PostageContract.batchDepth(entryProof.postageProof.postageId);
-        uint8 bucketDepth = PostageContract.batchBucketDepth(entryProof.postageProof.postageId);
         uint32 postageIndex = getPostageIndex(entryProof.postageProof.index);
         uint256 maxPostageIndex = postageStampIndexCount(batchDepth, bucketDepth);
         // available
@@ -956,8 +955,6 @@ contract Redistribution is AccessControl, Pausable {
             revert IndexOutsideSet(entryProof.postageProof.postageId);
         }
 
-        // available
-        address batchOwner = PostageContract.batchOwner(entryProof.postageProof.postageId);
 
         // alive
         if (PostageContract.remainingBalance(entryProof.postageProof.postageId) < PostageContract.minimumInitialBalancePerChunk()) {

--- a/src/interface/IPostageStamp.sol
+++ b/src/interface/IPostageStamp.sol
@@ -2,19 +2,30 @@
 pragma solidity ^0.8.19;
 
 interface IPostageStamp {
+    
     function withdraw(address beneficiary) external;
 
     function validChunkCount() external view returns (uint256);
 
-    function batchOwner(bytes32 _batchId) external view returns (address);
+    // Dont use commented out until we deploy new postagestamp contract that has this methods
+    // function batchOwner(bytes32 _batchId) external view returns (address);
 
-    function batchDepth(bytes32 _batchId) external view returns (uint8);
+    // function batchDepth(bytes32 _batchId) external view returns (uint8);
 
-    function batchBucketDepth(bytes32 _batchId) external view returns (uint8);
+    // function batchBucketDepth(bytes32 _batchId) external view returns (uint8);
 
     function remainingBalance(bytes32 _batchId) external view returns (uint256);
 
     function minimumInitialBalancePerChunk() external view returns (uint256);
 
     function setPrice(uint256 _price) external;
+
+    function batches(bytes32) external view returns (
+        address owner,
+        uint8 depth,
+        uint8 bucketDepth,
+        bool immutableFlag,
+        uint256 normalisedBalance,
+        uint256 lastUpdatedBlockNumber
+    );
 }


### PR DESCRIPTION
Add batches public function and use instead of currently used but not deployed methods