### PR TITLE
fix(redis): stamp alive check

### DIFF
--- a/src/PostageStamp.sol
+++ b/src/PostageStamp.sol
@@ -392,12 +392,12 @@ contract PostageStamp is AccessControl, Pausable {
         emit PriceUpdate(_price);
     }
 
-    function setMinimumValidityBlocks(uint256 _value) external {
+    function setMinimumValidityBlocks(uint64 _value) external {
         if (!hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) {
             revert AdministratorOnly();
         }
 
-        minimumValidityBlocks = uint64(_value);
+        minimumValidityBlocks = _value;
     }
 
     /**

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -1027,7 +1027,7 @@ contract Redistribution is AccessControl, Pausable {
         }
 
         // alive
-        if (PostageContract.remainingBalance(entryProof.postageProof.postageId) > 0) {
+        if (PostageContract.remainingBalance(entryProof.postageProof.postageId) <= 0) {
             revert BalanceValidationFailed(entryProof.postageProof.postageId);
         }
 

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -1015,10 +1015,10 @@ contract Redistribution is AccessControl, Pausable {
     }
 
     function stampFunction(ChunkInclusionProof calldata entryProof) internal view {
+        // authentic
         (address batchOwner, uint8 batchDepth, uint8 bucketDepth, , , ) = PostageContract.batches(
             entryProof.postageProof.postageId
         );
-        // authentic
         uint32 postageIndex = getPostageIndex(entryProof.postageProof.index);
         uint256 maxPostageIndex = postageStampIndexCount(batchDepth, bucketDepth);
         // available
@@ -1027,10 +1027,7 @@ contract Redistribution is AccessControl, Pausable {
         }
 
         // alive
-        if (
-            PostageContract.remainingBalance(entryProof.postageProof.postageId) <
-            PostageContract.minimumInitialBalancePerChunk()
-        ) {
+        if (PostageContract.remainingBalance(entryProof.postageProof.postageId) > 0) {
             revert BalanceValidationFailed(entryProof.postageProof.postageId);
         }
 


### PR DESCRIPTION
`stampFunction` had a stricter condition for the alive check of stamp so that mined chunks cannot be signed with short-living cheap postage batch. This condition is not that strict because a dishonest actor can keep up a single batch for this action which is not a significant expense.