### PR TITLE
chore: enable both roles local chain node and contracts deploy side job

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,4 @@ WORKDIR /app
 
 COPY --from=build /app .
 
-RUN ln -s /app/docker/deploy.sh /app/deploy.sh
-
 CMD ["sh", "-c", "/app/docker/deploy.sh"]

--- a/docker/deploy-contracts.sh
+++ b/docker/deploy-contracts.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -x
+while ! curl -m 1 http://geth-swap:8545; do sleep 1; done
+echo connected to geth >&2
+sleep 2
+
+npx hardhat deploy --network localcluster
+
+cd ./s3
+npx hardhat deploy --network localcluster
+
+echo deployed


### PR DESCRIPTION
This way we will have both scripts, we can run chain node on hardhat or use this container as a side job to deploy contracts to existing chain node.