### PR TITLE
fix: Remove pauser role

### DIFF
--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -156,9 +156,6 @@ contract Redistribution is AccessControl, Pausable {
     // Maximum value of the keccack256 hash.
     bytes32 private constant MAX_H = 0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff;
 
-    // Role allowed to pause.
-    bytes32 private immutable PAUSER_ROLE;
-
     // ----------------------------- Events ------------------------------
 
     /**
@@ -263,9 +260,7 @@ contract Redistribution is AccessControl, Pausable {
         Stakes = IStakeRegistry(staking);
         PostageContract = IPostageStamp(postageContract);
         OracleContract = IPriceOracle(oracleContract);
-        PAUSER_ROLE = keccak256("PAUSER_ROLE");
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _setupRole(PAUSER_ROLE, msg.sender);
     }
 
     ////////////////////////////////////////
@@ -659,7 +654,7 @@ contract Redistribution is AccessControl, Pausable {
      the pauser role and the admin role after pausing, can only be called by the `PAUSER`
      */
     function pause() public {
-        if (!hasRole(PAUSER_ROLE, msg.sender)) {
+        if (!hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) {
             revert OnlyPauser();
         }
 
@@ -670,7 +665,7 @@ contract Redistribution is AccessControl, Pausable {
      * @dev Unpause the contract, can only be called by the pauser when paused
      */
     function unPause() public {
-        if (!hasRole(PAUSER_ROLE, msg.sender)) {
+        if (!hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) {
             revert OnlyPauser();
         }
         _unpause();

--- a/src/Staking.sol
+++ b/src/Staking.sol
@@ -35,8 +35,6 @@ contract StakeRegistry is AccessControl, Pausable {
     // Associate every stake id with node address data.
     mapping(address => Stake) public stakes;
 
-    // Role allowed to pause
-    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
     // Role allowed to freeze and slash entries
     bytes32 public constant REDISTRIBUTOR_ROLE = keccak256("REDISTRIBUTOR_ROLE");
 
@@ -105,7 +103,6 @@ contract StakeRegistry is AccessControl, Pausable {
         bzzToken = _bzzToken;
         OracleContract = IPriceOracle(_oracleContract);
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _setupRole(PAUSER_ROLE, msg.sender);
     }
 
     ////////////////////////////////////////
@@ -223,7 +220,7 @@ contract StakeRegistry is AccessControl, Pausable {
      the pauser role and the admin role after pausing, can only be called by the `PAUSER`
      */
     function pause() public {
-        if (!hasRole(PAUSER_ROLE, msg.sender)) revert OnlyPauser();
+        if (!hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) revert OnlyPauser();
         _pause();
     }
 
@@ -231,7 +228,7 @@ contract StakeRegistry is AccessControl, Pausable {
      * @dev Unpause the contract, can only be called by the pauser when paused
      */
     function unPause() public {
-        if (!hasRole(PAUSER_ROLE, msg.sender)) revert OnlyPauser();
+        if (!hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) revert OnlyPauser();
         _unpause();
     }
 

--- a/test/PostageStamp.test.ts
+++ b/test/PostageStamp.test.ts
@@ -82,7 +82,7 @@ describe('PostageStamp', function () {
 
     it('should assign the pauser role', async function () {
       const postageStamp = await ethers.getContract('PostageStamp');
-      const pauserRole = await postageStamp.PAUSER_ROLE();
+      const pauserRole = await postageStamp.DEFAULT_ADMIN_ROLE();
       expect(await postageStamp.hasRole(pauserRole, deployer)).to.be.true;
     });
   });

--- a/test/Redistribution.test.ts
+++ b/test/Redistribution.test.ts
@@ -270,7 +270,7 @@ describe('Redistribution', function () {
       redistribution = await ethers.getContract('Redistribution');
       token = await ethers.getContract('TestToken', deployer);
 
-      const pauserRole = await read('StakeRegistry', 'PAUSER_ROLE');
+      const pauserRole = await read('StakeRegistry', 'DEFAULT_ADMIN_ROLE');
       await execute('StakeRegistry', { from: deployer }, 'grantRole', pauserRole, pauser);
 
       //initialise, set minimum price, todo: move to deployment

--- a/test/Staking.test.ts
+++ b/test/Staking.test.ts
@@ -81,7 +81,7 @@ describe('Staking', function () {
       await deployments.fixture();
       stakeRegistry = await ethers.getContract('StakeRegistry');
 
-      const pauserRole = await read('StakeRegistry', 'PAUSER_ROLE');
+      const pauserRole = await read('StakeRegistry', 'DEFAULT_ADMIN_ROLE');
       await execute('StakeRegistry', { from: deployer }, 'grantRole', pauserRole, pauser);
     });
 
@@ -90,7 +90,7 @@ describe('Staking', function () {
     });
 
     it('should set the pauser role', async function () {
-      const pauserRole = await stakeRegistry.PAUSER_ROLE();
+      const pauserRole = await stakeRegistry.DEFAULT_ADMIN_ROLE();
       expect(await stakeRegistry.hasRole(pauserRole, pauser)).to.be.true;
     });
 
@@ -288,7 +288,7 @@ describe('Staking', function () {
       await sr_staker_0.manageStake(nonce_0, stakeAmount_0);
 
       const stakeRegistryDeployer = await ethers.getContract('StakeRegistry', deployer);
-      const pauserRole = await stakeRegistryDeployer.PAUSER_ROLE();
+      const pauserRole = await stakeRegistryDeployer.DEFAULT_ADMIN_ROLE();
       await stakeRegistryDeployer.grantRole(pauserRole, pauser);
     });
 
@@ -358,7 +358,7 @@ describe('Staking', function () {
       updatedBlockNumber = await getBlockNumber();
 
       const stakeRegistryDeployer = await ethers.getContract('StakeRegistry', deployer);
-      const pauserRole = await stakeRegistryDeployer.PAUSER_ROLE();
+      const pauserRole = await stakeRegistryDeployer.DEFAULT_ADMIN_ROLE();
       await stakeRegistryDeployer.grantRole(pauserRole, pauser);
     });
 

--- a/test/Stats.test.ts
+++ b/test/Stats.test.ts
@@ -140,7 +140,7 @@ describe('Stats', async function () {
     const priceOracleRole = await read('PostageStamp', 'PRICE_ORACLE_ROLE');
     await execute('PostageStamp', { from: deployer }, 'grantRole', priceOracleRole, oracle);
 
-    const pauserRole = await read('StakeRegistry', 'PAUSER_ROLE');
+    const pauserRole = await read('StakeRegistry', 'DEFAULT_ADMIN_ROLE');
     await execute('StakeRegistry', { from: deployer }, 'grantRole', pauserRole, pauser);
 
     const priceOracle = await ethers.getContract('PriceOracle', deployer);


### PR DESCRIPTION
As we currently use the same multistig for pauser and for default admin there is probably no need to have both roles defined and set and then used from the same address. So I am proposing we remove pauser role and just use admin role.