### PR TITLE
feat: change stamp to fit for multichain solution

### DIFF
--- a/src/PostageStamp.sol
+++ b/src/PostageStamp.sol
@@ -218,7 +218,7 @@ contract PostageStamp is AccessControl, Pausable {
         }
 
         uint256 totalAmount = _initialBalancePerChunk * (1 << _depth);
-        // We keep msg.sender as tokens can be transfered through smart contract from the owner
+        // We keep msg.sender as tokens can be transfered through proxy such as LIFI smart contract from the owner
         if (!ERC20(bzzToken).transferFrom(msg.sender, address(this), totalAmount)) {
             revert TransferFailed();
         }
@@ -389,7 +389,7 @@ contract PostageStamp is AccessControl, Pausable {
     function increaseDepth(bytes32 _batchId, uint8 _newDepth) external whenNotPaused {
         Batch memory batch = batches[_batchId];
 
-        if (batch.owner != msg.sender) {
+        if (batch.creator != msg.sender) {
             revert NotBatchOwner();
         }
 

--- a/tasks/deployments.ts
+++ b/tasks/deployments.ts
@@ -15,7 +15,7 @@ interface NetworkDeployment {
 }
 
 const ETHERSCAN_URLS = {
-  mainnet: 'https://etherscan.io/address/',
+  mainnet: 'https://gnosisscan.io/address/',
   sepolia: 'https://sepolia.etherscan.io/address/',
 };
 


### PR DESCRIPTION
To make postagestamp work properly with multichain and that we can distinguish who paid stamps and who created it we added creator value to batch. Creator will be Node address that is created stamp and uploading data, but owner may be not but could also be a user that is just uploading data through multichain solution dapp or some other way. So we can distinguish who is paying/owning the stamp and who is creating and uploading.

Will require migration of current stamps 
Will require bee node to change behaviour as there is more parameters and also batch ID is created per owner address and not msg.sender.
Once this is implemented, then multichain solution can created batchIDs based on owner of stamp and upload as such.
The same thing needs to be applied to bee nodes, that upload header for "swarm-postage-batch-id" is matching owner plus nonce.