### PR TITLE
Fix:change order errors

### DIFF
--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -368,16 +368,19 @@ contract Redistribution is AccessControl, Pausable {
         uint64 cr = currentRound();
         bytes32 _overlay = Stakes.overlayOfAddress(msg.sender);
 
-        if (_depth < currentMinimumDepth()) {
-            revert OutOfDepth();
+        // 1. Check round validity first (cheapest)
+        if (cr != currentCommitRound) {
+            revert NoCommitsReceived();
         }
 
+        // 2. Check phase within the round (more expensive)
         if (!currentPhaseReveal()) {
             revert NotRevealPhase();
         }
 
-        if (cr != currentCommitRound) {
-            revert NoCommitsReceived();
+        // 3. Check application-specific requirements (last)
+        if (_depth < currentMinimumDepth()) {
+            revert OutOfDepth();
         }
 
         if (cr != currentRevealRound) {

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -296,17 +296,14 @@ contract Redistribution is AccessControl, Pausable {
         uint256 _lastUpdate = Stakes.lastUpdatedBlockNumberOfAddress(msg.sender);
         uint8 _height = Stakes.heightOfAddress(msg.sender);
 
-        // 1. Check basic eligibility first (cheapest check)
         if (_lastUpdate == 0) {
             revert NotStaked();
         }
 
-        // 2. Check staking duration requirement (simple arithmetic)
         if (_lastUpdate >= block.number - 2 * ROUND_LENGTH) {
             revert MustStake2Rounds();
         }
 
-        // 3. Check round number validity (simple comparisons)
         if (cr > _roundNumber) {
             revert CommitRoundOver();
         }
@@ -315,7 +312,6 @@ contract Redistribution is AccessControl, Pausable {
             revert CommitRoundNotStarted();
         }
 
-        // 4. Check phase within the round (more expensive modulo operations)
         if (!currentPhaseCommit()) {
             revert NotCommitPhase();
         }
@@ -368,17 +364,14 @@ contract Redistribution is AccessControl, Pausable {
         uint64 cr = currentRound();
         bytes32 _overlay = Stakes.overlayOfAddress(msg.sender);
 
-        // 1. Check round validity first (cheapest)
         if (cr != currentCommitRound) {
             revert NoCommitsReceived();
         }
 
-        // 2. Check phase within the round (more expensive)
         if (!currentPhaseReveal()) {
             revert NotRevealPhase();
         }
 
-        // 3. Check application-specific requirements (last)
         if (_depth < currentMinimumDepth()) {
             revert OutOfDepth();
         }

--- a/test/Redistribution.test.ts
+++ b/test/Redistribution.test.ts
@@ -669,6 +669,10 @@ describe('Redistribution', function () {
         expect(await redistribution.currentPhaseCommit()).to.be.true;
 
         const r_node_0 = await ethers.getContract('Redistribution', node_0);
+        
+        // First make a commit so we can test phase validation
+        const currentRound = await r_node_0.currentRound();
+        await r_node_0.commit(obfuscatedHash_0, currentRound);
 
         await expect(r_node_0.reveal(depth_0, reveal_nonce_0, revealed_overlay_0)).to.be.revertedWith(
           errors.reveal.notInReveal
@@ -683,6 +687,10 @@ describe('Redistribution', function () {
         expect(await redistribution.currentPhaseReveal()).to.be.false;
 
         const r_node_0 = await ethers.getContract('Redistribution', node_0);
+        
+        // First make a commit so we can test phase validation
+        const currentRound = await r_node_0.currentRound();
+        await r_node_0.commit(obfuscatedHash_0, currentRound);
 
         await mineNBlocks(phaseLength * 2);
         expect(await redistribution.currentPhaseClaim()).to.be.true;


### PR DESCRIPTION
This optimization will:
✅ Save gas by doing cheap checks first
✅ **Provide better user experience with logical error ordering**
✅ Exit early on the most common validation failures
✅ Only perform expensive modulo calculations when really needed