### PR TITLE
feat: defang skipped rounds penalty 

### DIFF
--- a/src/PriceOracle.sol
+++ b/src/PriceOracle.sol
@@ -134,9 +134,9 @@ contract PriceOracle is AccessControl {
             uint32 _changeRate = changeRate[usedRedundancy];
             _currentPriceUpScaled = (_changeRate * _currentPriceUpScaled) / _priceBase;
 
-            // If previous rounds were skipped, use MAX price increase for the previous rounds
+            // If previous rounds were skipped, use rate as if 1 player participated (defanged approach)
             if (skippedRounds > 0) {
-                _changeRate = changeRate[0];
+                _changeRate = changeRate[1]; // Use redundancy=1 rate instead of max penalty
                 for (uint64 i = 0; i < skippedRounds; i++) {
                     _currentPriceUpScaled = (_changeRate * _currentPriceUpScaled) / _priceBase;
                 }

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -335,16 +335,16 @@ describe('PriceOracle', function () {
 
         // Now call adjustPrice with redundancy=2
         const currentRedundancy = 2;
-        
+
         // Calculate what the price would be with OLD approach (changeRate[0])
         // This uses the maximum penalty for skipped rounds
         let oldApproachPriceUpscaled = price1 << 10;
-        
+
         // Apply changeRate[0] for skipped rounds (old approach)
         for (let i = 0; i < skippedRounds; i++) {
           oldApproachPriceUpscaled = Math.floor((changeRate[0] * oldApproachPriceUpscaled) / priceBase);
         }
-        
+
         // Apply changeRate[2] for current round
         oldApproachPriceUpscaled = Math.floor((changeRate[currentRedundancy] * oldApproachPriceUpscaled) / priceBase);
         const oldApproachPrice = oldApproachPriceUpscaled >> 10;
@@ -360,12 +360,12 @@ describe('PriceOracle', function () {
 
         // Calculate the expected price with NEW approach for verification
         let newApproachPriceUpscaled = price1 << 10;
-        
+
         // Apply changeRate[1] for skipped rounds (new defanged approach)
         for (let i = 0; i < skippedRounds; i++) {
           newApproachPriceUpscaled = Math.floor((changeRate[1] * newApproachPriceUpscaled) / priceBase);
         }
-        
+
         // Apply changeRate[2] for current round
         newApproachPriceUpscaled = Math.floor((changeRate[currentRedundancy] * newApproachPriceUpscaled) / priceBase);
         const newApproachPrice = newApproachPriceUpscaled >> 10;
@@ -376,7 +376,12 @@ describe('PriceOracle', function () {
         // Log the difference for documentation
         console.log(`        Price with changeRate[0] (old): ${oldApproachPrice}`);
         console.log(`        Price with changeRate[1] (new): ${finalPrice}`);
-        console.log(`        Difference: ${oldApproachPrice - finalPrice} (${((oldApproachPrice - finalPrice) / oldApproachPrice * 100).toFixed(2)}%)`);
+        console.log(
+          `        Difference: ${oldApproachPrice - finalPrice} (${(
+            ((oldApproachPrice - finalPrice) / oldApproachPrice) *
+            100
+          ).toFixed(2)}%)`
+        );
       });
     });
   });

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -316,6 +316,68 @@ describe('PriceOracle', function () {
         expect(await priceOracle.currentPrice()).to.be.eq(newPrice4);
         expect(await postageStamp.lastPrice()).to.be.eq(newPrice4);
       });
+
+      it('should apply defanged penalty for skipped rounds (changeRate[1] instead of changeRate[0])', async function () {
+        const priceOracleU = await ethers.getContract('PriceOracle', updater);
+
+        const currentPrice = await priceOracle.currentPrice();
+        expect(currentPrice).to.be.eq(minimumPrice);
+
+        // Advance one round and set initial price with redundancy=4 (neutral)
+        await mineNBlocks(roundLength);
+        await priceOracleU.adjustPrice(4);
+
+        const price1 = await priceOracle.currentPrice();
+
+        // Skip 3 rounds (mine 3 * roundLength blocks + 1 to ensure we're in the 4th round)
+        const skippedRounds = 3;
+        await mineNBlocks(roundLength * (skippedRounds + 1));
+
+        // Now call adjustPrice with redundancy=2
+        const currentRedundancy = 2;
+        
+        // Calculate what the price would be with OLD approach (changeRate[0])
+        // This uses the maximum penalty for skipped rounds
+        let oldApproachPriceUpscaled = price1 << 10;
+        
+        // Apply changeRate[0] for skipped rounds (old approach)
+        for (let i = 0; i < skippedRounds; i++) {
+          oldApproachPriceUpscaled = Math.floor((changeRate[0] * oldApproachPriceUpscaled) / priceBase);
+        }
+        
+        // Apply changeRate[2] for current round
+        oldApproachPriceUpscaled = Math.floor((changeRate[currentRedundancy] * oldApproachPriceUpscaled) / priceBase);
+        const oldApproachPrice = oldApproachPriceUpscaled >> 10;
+
+        // Now actually call adjustPrice and see what we get with NEW defanged approach
+        await priceOracleU.adjustPrice(currentRedundancy);
+
+        const finalPrice = await priceOracle.currentPrice();
+
+        // The key test: final price should be LESS than what it would be with changeRate[0]
+        // because we're using changeRate[1] instead (defanged approach)
+        expect(finalPrice).to.be.lt(oldApproachPrice);
+
+        // Calculate the expected price with NEW approach for verification
+        let newApproachPriceUpscaled = price1 << 10;
+        
+        // Apply changeRate[1] for skipped rounds (new defanged approach)
+        for (let i = 0; i < skippedRounds; i++) {
+          newApproachPriceUpscaled = Math.floor((changeRate[1] * newApproachPriceUpscaled) / priceBase);
+        }
+        
+        // Apply changeRate[2] for current round
+        newApproachPriceUpscaled = Math.floor((changeRate[currentRedundancy] * newApproachPriceUpscaled) / priceBase);
+        const newApproachPrice = newApproachPriceUpscaled >> 10;
+
+        // Verify the actual price matches our calculation
+        expect(finalPrice).to.be.eq(newApproachPrice);
+
+        // Log the difference for documentation
+        console.log(`        Price with changeRate[0] (old): ${oldApproachPrice}`);
+        console.log(`        Price with changeRate[1] (new): ${finalPrice}`);
+        console.log(`        Difference: ${oldApproachPrice - finalPrice} (${((oldApproachPrice - finalPrice) / oldApproachPrice * 100).toFixed(2)}%)`);
+      });
     });
   });
 });

--- a/test/Redistribution.test.ts
+++ b/test/Redistribution.test.ts
@@ -1402,10 +1402,11 @@ describe('Redistribution', function () {
             expect(WinnerSelectedEvent.args[0].depth).to.be.eq(parseInt(depth_5));
 
             // Check if the increase is properly applied, we have 3 skipped round here
+            // Using increaseRate[1] for defanged approach (as if 1 player participated)
             currentPriceUpScaled = (increaseRate[nodesInNeighbourhood] * currentPriceUpScaled) / basePrice;
             skippedRounds = 3;
             expect(await postage.lastPrice()).to.be.eq(
-              await skippedRoundsIncrease(skippedRounds, currentPriceUpScaled, basePrice, increaseRate[0])
+              await skippedRoundsIncrease(skippedRounds, currentPriceUpScaled, basePrice, increaseRate[1])
             );
 
             const sr = await ethers.getContract('StakeRegistry');
@@ -1466,10 +1467,11 @@ describe('Redistribution', function () {
             expect(WinnerSelectedEvent.args[0].depth).to.be.eq(parseInt(depth_5));
 
             // Check if the increase is properly applied, we have 3 skipped round here
+            // Using increaseRate[1] for defanged approach (as if 1 player participated)
             currentPriceUpScaled = (increaseRate[nodesInNeighbourhood] * currentPriceUpScaled) / basePrice;
             skippedRounds = 3;
             expect(await postage.lastPrice()).to.be.eq(
-              await skippedRoundsIncrease(skippedRounds, currentPriceUpScaled, basePrice, increaseRate[0])
+              await skippedRoundsIncrease(skippedRounds, currentPriceUpScaled, basePrice, increaseRate[1])
             );
 
             expect(TruthSelectedEvent.args[0]).to.be.eq(hash_5);


### PR DESCRIPTION
Changes the skipped rounds price adjustment to use changeRate[1] (as if 1 player participated) instead of changeRate[0] (maximum penalty for no players).
