### PR TITLE
fix(redis): extract virtual randomness hook for fuzz harnesses

### DIFF
--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -671,8 +671,13 @@ contract Redistribution is AccessControl, Pausable {
      * @notice Updates the source of randomness. Uses block.difficulty in pre-merge chains, this is substituted
      * to block.prevrandao in post merge chains.
      */
-    function updateRandomness() private {
-        seed = keccak256(abi.encode(seed, block.prevrandao));
+    function updateRandomness() internal virtual {
+        seed = _nextSeedValue();
+    }
+
+    /// @dev Extracted for fuzz harnesses that must pin post-reveal randomness to fixture data.
+    function _nextSeedValue() internal view virtual returns (bytes32) {
+        return keccak256(abi.encode(seed, block.prevrandao));
     }
 
     /**


### PR DESCRIPTION
## Summary
- Make `updateRandomness` `internal virtual` and extract `_nextSeedValue` so test/fuzz wrappers can override post-reveal randomness without changing production semantics.

## Test plan
- [ ] Run existing Redistribution unit tests
- [ ] Confirm production `updateRandomness` behavior is unchanged (same keccak256 seed update)
- [ ] Verify fuzz harness subclasses can override `_nextSeedValue` when needed