### PR TITLE
fix(stamp): cast before min initial balance multiply

### DIFF
--- a/src/PostageStamp.sol
+++ b/src/PostageStamp.sol
@@ -566,7 +566,8 @@ contract PostageStamp is AccessControl, Pausable {
     }
 
     function minimumInitialBalancePerChunk() public view returns (uint256) {
-        return minimumValidityBlocks * lastPrice;
+        // Cast to uint256 before multiplying to avoid uint64 overflow.
+        return uint256(minimumValidityBlocks) * uint256(lastPrice);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Cast `minimumValidityBlocks` and `lastPrice` to `uint256` before multiplying in `minimumInitialBalancePerChunk()`.
- Prevents silent uint64 overflow when computing the minimum required per-chunk balance.

## Test plan
- [ ] Run existing PostageStamp unit tests
- [ ] Verify `minimumInitialBalancePerChunk()` matches `uint256(minimumValidityBlocks) * uint256(lastPrice)` at high `lastPrice` values
- [ ] Confirm batch create/topup/expiry checks still enforce the minimum balance correctly