### PR TITLE
fix(stamp): remove unused immutable batch flag

### DIFF
--- a/docs/POSTAGE_STAMP.md
+++ b/docs/POSTAGE_STAMP.md
@@ -33,7 +33,6 @@ struct Batch {
     address owner;                    // Owner of the batch
     uint8 depth;                      // Total depth (2^depth = max chunks)
     uint8 bucketDepth;               // Bucket depth for addressing
-    bool immutableFlag;              // Whether batch can be modified
     uint256 normalisedBalance;       // Normalized balance per chunk
     uint256 lastUpdatedBlockNumber;   // Last update timestamp
 }
@@ -59,7 +58,6 @@ Creates a new postage stamp batch.
 - `_depth`: Total batch depth (capacity = 2^depth)
 - `_bucketDepth`: Bucket depth for chunk addressing
 - `_nonce`: Random nonce for batch ID generation
-- `_immutable`: Whether batch can be topped up later
 
 **Requirements**:
 - `_initialBalancePerChunk >= minimumInitialBalancePerChunk()` (24h minimum validity)
@@ -207,8 +205,7 @@ event BatchCreated(
     uint256 normalisedBalance,
     address owner,
     uint8 depth,
-    uint8 bucketDepth,
-    bool immutableFlag
+    uint8 bucketDepth
 );
 
 event BatchTopUp(

--- a/scripts/migration/import.sh
+++ b/scripts/migration/import.sh
@@ -11,12 +11,11 @@ for row in $(cat ./migration/batchesG2.json | jq -c '.batches[]'); do
     depth=$(_field $row ".depth")
     bucketdepth=$(_field $row ".bucketDepth")
     batchid=$(_field $row ".batchid")
-    immutable=$(_field $row ".immutable")
 
     echo "Batch balance #####"
     echo ${balance}
 
-    cmd="npx hardhat --network testnet copy --owner ${owner} --initialbalance ${balance}  --depth ${depth} --bucketdepth ${bucketdepth}  --batchid ${batchid}  --immutable ${immutable} --contract ${postagecontract}"
+    cmd="npx hardhat --network testnet copy --owner ${owner} --initialbalance ${balance}  --depth ${depth} --bucketdepth ${bucketdepth}  --batchid ${batchid} --contract ${postagecontract}"
     $cmd
     [ $? -eq 0 ] && echo "${batchid} migration successful" || echo "${batchid} migration failure"
 done

--- a/scripts/migration/import.ts
+++ b/scripts/migration/import.ts
@@ -6,7 +6,6 @@ interface Batch {
   owner: string;
   depth: number;
   bucketDepth: number;
-  immutable: boolean;
   remainingBalance: number;
 }
 
@@ -39,7 +38,6 @@ async function main() {
       owner: batch.owner,
       depth: batch.depth,
       bucketDepth: batch.bucketDepth,
-      immutableFlag: batch.immutable,
       remainingBalance: batch.remainingBalance,
     }));
 

--- a/src/PostageStamp.sol
+++ b/src/PostageStamp.sol
@@ -301,13 +301,7 @@ contract PostageStamp is AccessControl, Pausable {
         for (uint i = 0; i < bulkBatches.length; i++) {
             ImportBatch memory _batch = bulkBatches[i];
             try
-                this.copyBatch(
-                    _batch.owner,
-                    _batch.remainingBalance,
-                    _batch.depth,
-                    _batch.bucketDepth,
-                    _batch.batchId
-                )
+                this.copyBatch(_batch.owner, _batch.remainingBalance, _batch.depth, _batch.bucketDepth, _batch.batchId)
             {
                 // Successful copyBatch call
             } catch {

--- a/src/PostageStamp.sol
+++ b/src/PostageStamp.sol
@@ -79,8 +79,6 @@ contract PostageStamp is AccessControl, Pausable {
         uint8 depth;
         // Bucket depth defined in this batch
         uint8 bucketDepth;
-        // Whether this batch is immutable.
-        bool immutableFlag;
         // Normalised balance per chunk.
         uint256 normalisedBalance;
         // When was this batch last updated
@@ -92,7 +90,6 @@ contract PostageStamp is AccessControl, Pausable {
         address owner;
         uint8 depth;
         uint8 bucketDepth;
-        bool immutableFlag;
         uint256 remainingBalance;
     }
 
@@ -107,8 +104,7 @@ contract PostageStamp is AccessControl, Pausable {
         uint256 normalisedBalance,
         address owner,
         uint8 depth,
-        uint8 bucketDepth,
-        bool immutableFlag
+        uint8 bucketDepth
     );
 
     /**
@@ -184,15 +180,13 @@ contract PostageStamp is AccessControl, Pausable {
      * @param _initialBalancePerChunk Initial balance per chunk.
      * @param _depth Initial depth of the new batch.
      * @param _nonce A random value used in the batch id derivation to allow multiple batches per owner.
-     * @param _immutable Whether the batch is mutable.
      */
     function createBatch(
         address _owner,
         uint256 _initialBalancePerChunk,
         uint8 _depth,
         uint8 _bucketDepth,
-        bytes32 _nonce,
-        bool _immutable
+        bytes32 _nonce
     ) external whenNotPaused returns (bytes32) {
         if (_owner == address(0)) {
             revert ZeroAddress();
@@ -228,14 +222,13 @@ contract PostageStamp is AccessControl, Pausable {
             owner: _owner,
             depth: _depth,
             bucketDepth: _bucketDepth,
-            immutableFlag: _immutable,
             normalisedBalance: normalisedBalance,
             lastUpdatedBlockNumber: block.number
         });
 
         tree.insert(batchId, normalisedBalance);
 
-        emit BatchCreated(batchId, totalAmount, normalisedBalance, _owner, _depth, _bucketDepth, _immutable);
+        emit BatchCreated(batchId, totalAmount, normalisedBalance, _owner, _depth, _bucketDepth);
 
         return batchId;
     }
@@ -247,15 +240,13 @@ contract PostageStamp is AccessControl, Pausable {
      * @param _initialBalancePerChunk Initial balance per chunk of the batch.
      * @param _depth Initial depth of the new batch.
      * @param _batchId BatchId being copied (from previous version contract data).
-     * @param _immutable Whether the batch is mutable.
      */
     function copyBatch(
         address _owner,
         uint256 _initialBalancePerChunk,
         uint8 _depth,
         uint8 _bucketDepth,
-        bytes32 _batchId,
-        bool _immutable
+        bytes32 _batchId
     ) public whenNotPaused {
         if (!hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) {
             revert AdministratorOnly();
@@ -288,14 +279,13 @@ contract PostageStamp is AccessControl, Pausable {
             owner: _owner,
             depth: _depth,
             bucketDepth: _bucketDepth,
-            immutableFlag: _immutable,
             normalisedBalance: normalisedBalance,
             lastUpdatedBlockNumber: block.number
         });
 
         tree.insert(_batchId, normalisedBalance);
 
-        emit BatchCreated(_batchId, totalAmount, normalisedBalance, _owner, _depth, _bucketDepth, _immutable);
+        emit BatchCreated(_batchId, totalAmount, normalisedBalance, _owner, _depth, _bucketDepth);
     }
 
     /**
@@ -316,8 +306,7 @@ contract PostageStamp is AccessControl, Pausable {
                     _batch.remainingBalance,
                     _batch.depth,
                     _batch.bucketDepth,
-                    _batch.batchId,
-                    _batch.immutableFlag
+                    _batch.batchId
                 )
             {
                 // Successful copyBatch call
@@ -626,10 +615,6 @@ contract PostageStamp is AccessControl, Pausable {
 
     function batchBucketDepth(bytes32 _batchId) public view returns (uint8) {
         return batches[_batchId].bucketDepth;
-    }
-
-    function batchImmutableFlag(bytes32 _batchId) public view returns (bool) {
-        return batches[_batchId].immutableFlag;
     }
 
     function batchNormalisedBalance(bytes32 _batchId) public view returns (uint256) {

--- a/src/Redistribution.sol
+++ b/src/Redistribution.sol
@@ -1062,7 +1062,7 @@ contract Redistribution is AccessControl, Pausable {
 
     function stampFunction(ChunkInclusionProof calldata entryProof) internal view {
         // authentic
-        (address batchOwner, uint8 batchDepth, uint8 bucketDepth, , , ) = PostageContract.batches(
+        (address batchOwner, uint8 batchDepth, uint8 bucketDepth, , ) = PostageContract.batches(
             entryProof.postageProof.postageId
         );
 

--- a/src/echidna/EchidnaPostageStampHarness.sol
+++ b/src/echidna/EchidnaPostageStampHarness.sol
@@ -14,7 +14,7 @@ contract EchidnaPostageActor {
         token.approve(address(stamp), type(uint256).max);
     }
 
-    function createBatchMutable(
+    function createBatch(
         uint256 initialBalancePerChunk,
         uint8 depth,
         uint8 bucketDepth,
@@ -28,29 +28,7 @@ contract EchidnaPostageActor {
                 initialBalancePerChunk,
                 depth,
                 bucketDepth,
-                nonce,
-                false
-            )
-        );
-        if (ok && data.length >= 32) batchId = abi.decode(data, (bytes32));
-    }
-
-    function createBatchImmutable(
-        uint256 initialBalancePerChunk,
-        uint8 depth,
-        uint8 bucketDepth,
-        bytes32 nonce
-    ) external returns (bool ok, bytes32 batchId) {
-        bytes memory data;
-        (ok, data) = address(stamp).call(
-            abi.encodeWithSelector(
-                stamp.createBatch.selector,
-                address(this),
-                initialBalancePerChunk,
-                depth,
-                bucketDepth,
-                nonce,
-                true
+                nonce
             )
         );
         if (ok && data.length >= 32) batchId = abi.decode(data, (bytes32));
@@ -113,7 +91,6 @@ contract EchidnaPostageStampHarness {
     uint256 internal pendingCreateNormalisedExpected;
     uint8 internal pendingCreateDepth;
     uint8 internal pendingCreateBucketDepth;
-    bool internal pendingCreateImmutable;
 
     bool internal pendingTopUp;
     bytes32 internal pendingTopUpBatchId;
@@ -146,7 +123,6 @@ contract EchidnaPostageStampHarness {
 
     // Temporary inputs to reduce stack pressure in helpers.
     bytes32 internal tmpNonce;
-    bool internal tmpImmutable;
     bytes32 internal tmpBatchA;
     bytes32 internal tmpBatchB;
     bytes32 internal tmpBatchC;
@@ -197,14 +173,12 @@ contract EchidnaPostageStampHarness {
         uint8 actorId,
         uint256 initialPerChunk,
         uint8 depthRaw,
-        bytes32 nonce,
-        bool immutableFlag
+        bytes32 nonce
     ) external {
         _clearPending();
         // Normalize expiry so createBatch's internal expireLimited() doesn't unexpectedly mutate other batches.
         stamp.expireLimited(type(uint256).max);
         tmpNonce = nonce;
-        tmpImmutable = immutableFlag;
         _createBatchInternal(actorId, initialPerChunk, depthRaw);
         _observePot(false);
     }
@@ -424,7 +398,6 @@ contract EchidnaPostageStampHarness {
         if (stamp.batchOwner(pendingBatchId) == address(0)) return false;
         if (stamp.batchDepth(pendingBatchId) != pendingCreateDepth) return false;
         if (stamp.batchBucketDepth(pendingBatchId) != pendingCreateBucketDepth) return false;
-        if (stamp.batchImmutableFlag(pendingBatchId) != pendingCreateImmutable) return false;
 
         // Normalised balance is computed as currentTotalOutPayment + perChunk at creation time.
         if (stamp.batchNormalisedBalance(pendingBatchId) != pendingCreateNormalisedExpected) return false;
@@ -497,7 +470,6 @@ contract EchidnaPostageStampHarness {
         pendingCreateNormalisedExpected = 0;
         pendingCreateDepth = 0;
         pendingCreateBucketDepth = 0;
-        pendingCreateImmutable = false;
 
         pendingTopUp = false;
         pendingTopUpBatchId = bytes32(0);
@@ -537,7 +509,6 @@ contract EchidnaPostageStampHarness {
                     owner,
                     stamp.batchDepth(batchId),
                     stamp.batchBucketDepth(batchId),
-                    stamp.batchImmutableFlag(batchId),
                     stamp.batchNormalisedBalance(batchId),
                     stamp.batchLastUpdatedBlockNumber(batchId)
                 )
@@ -604,15 +575,8 @@ contract EchidnaPostageStampHarness {
         pendingCreateNormalisedExpected = stamp.currentTotalOutPayment() + perChunk;
         pendingCreateDepth = depth;
         pendingCreateBucketDepth = bucketDepth;
-        pendingCreateImmutable = tmpImmutable;
 
-        bool ok;
-        bytes32 batchId;
-        if (tmpImmutable) {
-            (ok, batchId) = a.createBatchImmutable(perChunk, depth, bucketDepth, tmpNonce);
-        } else {
-            (ok, batchId) = a.createBatchMutable(perChunk, depth, bucketDepth, tmpNonce);
-        }
+        (bool ok, bytes32 batchId) = a.createBatch(perChunk, depth, bucketDepth, tmpNonce);
         if (!ok || batchId == bytes32(0)) return;
 
         tracked[trackedCount % MAX_TRACKED] = batchId;

--- a/src/echidna/EchidnaPostageStampHarness.sol
+++ b/src/echidna/EchidnaPostageStampHarness.sol
@@ -169,12 +169,7 @@ contract EchidnaPostageStampHarness {
         token.transfer(address(_actor(actorId)), x);
     }
 
-    function act_createBatch(
-        uint8 actorId,
-        uint256 initialPerChunk,
-        uint8 depthRaw,
-        bytes32 nonce
-    ) external {
+    function act_createBatch(uint8 actorId, uint256 initialPerChunk, uint8 depthRaw, bytes32 nonce) external {
         _clearPending();
         // Normalize expiry so createBatch's internal expireLimited() doesn't unexpectedly mutate other batches.
         stamp.expireLimited(type(uint256).max);

--- a/src/echidna/EchidnaRedistributionClaimHarness.sol
+++ b/src/echidna/EchidnaRedistributionClaimHarness.sol
@@ -73,12 +73,11 @@ contract EchidnaPostageStampPotMock is IPostageStamp {
             address owner,
             uint8 depth,
             uint8 bucketDepth,
-            bool immutableFlag,
             uint256 normalisedBalance,
             uint256 lastUpdatedBlockNumber
         )
     {
-        return (address(0), 0, 0, false, 0, 0);
+        return (address(0), 0, 0, 0, 0);
     }
 }
 

--- a/src/echidna/EchidnaRedistributionHarness.sol
+++ b/src/echidna/EchidnaRedistributionHarness.sol
@@ -50,12 +50,11 @@ contract EchidnaPostageStampMock is IPostageStamp {
             address owner,
             uint8 depth,
             uint8 bucketDepth,
-            bool immutableFlag,
             uint256 normalisedBalance,
             uint256 lastUpdatedBlockNumber
         )
     {
-        return (address(0), 0, 0, false, 0, 0);
+        return (address(0), 0, 0, 0, 0);
     }
 }
 

--- a/src/echidna/EchidnaSystemHarness.sol
+++ b/src/echidna/EchidnaSystemHarness.sol
@@ -39,8 +39,7 @@ contract EchidnaSystemActor {
         uint256 initialBalancePerChunk,
         uint8 depth,
         uint8 bucketDepth,
-        bytes32 nonce,
-        bool immutableFlag
+        bytes32 nonce
     ) external returns (bool ok) {
         (ok, ) = address(stamp).call(
             abi.encodeWithSelector(
@@ -49,8 +48,7 @@ contract EchidnaSystemActor {
                 initialBalancePerChunk,
                 depth,
                 bucketDepth,
-                nonce,
-                immutableFlag
+                nonce
             )
         );
     }
@@ -167,8 +165,7 @@ contract EchidnaSystemHarness {
         uint256 initialBalancePerChunk,
         uint8 depth,
         uint8 bucketDepth,
-        bytes32 nonce,
-        bool imm
+        bytes32 nonce
     ) external {
         EchidnaSystemActor a = actors[uint256(actorId) % ACTOR_COUNT];
         uint8 minBucket = stamp.minimumBucketDepth();
@@ -182,7 +179,7 @@ contract EchidnaSystemHarness {
         if (init < min) init = min;
         if (init == 0) init = 1;
 
-        a.callCreateBatch(address(a), init, d, b, nonce, imm);
+        a.callCreateBatch(address(a), init, d, b, nonce);
     }
 
     function act_actor_topUp(uint8 actorId, bytes32 batchId, uint256 topupAmountPerChunk) external {

--- a/src/echidna/EchidnaSystemHarness.sol
+++ b/src/echidna/EchidnaSystemHarness.sol
@@ -42,14 +42,7 @@ contract EchidnaSystemActor {
         bytes32 nonce
     ) external returns (bool ok) {
         (ok, ) = address(stamp).call(
-            abi.encodeWithSelector(
-                stamp.createBatch.selector,
-                owner,
-                initialBalancePerChunk,
-                depth,
-                bucketDepth,
-                nonce
-            )
+            abi.encodeWithSelector(stamp.createBatch.selector, owner, initialBalancePerChunk, depth, bucketDepth, nonce)
         );
     }
 

--- a/src/interface/IPostageStamp.sol
+++ b/src/interface/IPostageStamp.sol
@@ -27,7 +27,6 @@ interface IPostageStamp {
             address owner,
             uint8 depth,
             uint8 bucketDepth,
-            bool immutableFlag,
             uint256 normalisedBalance,
             uint256 lastUpdatedBlockNumber
         );

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -191,7 +191,6 @@ npx hardhat copy \
   --depth 20 \
   --bucketdepth 16 \
   --batchid 0xabcd... \
-  --immutable false \
   --contract 0x5678...
 ```
 
@@ -202,7 +201,6 @@ npx hardhat copy \
 - `--depth`: Batch depth
 - `--bucketdepth`: Bucket depth
 - `--batchid`: Batch ID
-- `--immutable`: Whether batch is immutable (true/false)
 - `--contract`: PostageStamp contract address
 
 #### What it does

--- a/tasks/copybatch.ts
+++ b/tasks/copybatch.ts
@@ -8,7 +8,6 @@
  *     --depth 20 \
  *     --bucketdepth 16 \
  *     --batchid 0xabcd... \
- *     --immutable false \
  *     --contract 0x5678...
  *
  * Parameters:
@@ -17,7 +16,6 @@
  *   --depth: Batch depth
  *   --bucketdepth: Bucket depth
  *   --batchid: Batch ID
- *   --immutable: Whether batch is immutable (true/false)
  *   --contract: PostageStamp contract address
  *
  * This task:
@@ -34,7 +32,6 @@ interface TaskArguments {
   depth: string;
   bucketdepth: string;
   batchid: string;
-  immutable: string;
   contract: string;
 }
 
@@ -44,7 +41,6 @@ task('copy', 'Use copyBatch function from postageStamp contract')
   .addParam('depth', "The account's address")
   .addParam('bucketdepth', "The account's address")
   .addParam('batchid', "The account's address")
-  .addParam('immutable', "The account's address")
   .addParam('contract', 'Postage Stamp contract address')
 
   .setAction(async (taskArgs: TaskArguments, hre) => {

--- a/test/PostageStamp.test.ts
+++ b/test/PostageStamp.test.ts
@@ -9,7 +9,6 @@ interface Batch {
   nonce: string;
   initialPaymentPerChunk: number;
   depth: number;
-  immutable: boolean;
   bucketDepth: number;
 }
 
@@ -120,7 +119,6 @@ describe('PostageStamp', function () {
           nonce: '0x000000000000000000000000000000000000000000000000000000000000abcd',
           initialPaymentPerChunk: price0 * 10, //good for ten blocks at minimum price
           depth: 17,
-          immutable: false,
           bucketDepth: 16,
         };
 
@@ -141,8 +139,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk,
             batch.depth,
             batch.bucketDepth,
-            batch.nonce,
-            batch.immutable
+            batch.nonce
           )
         )
           .to.emit(postageStampStamper, 'BatchCreated')
@@ -152,8 +149,7 @@ describe('PostageStamp', function () {
             expectedNormalisedBalance,
             stamper,
             batch.depth,
-            batch.bucketDepth,
-            batch.immutable
+            batch.bucketDepth
           );
       });
 
@@ -165,15 +161,13 @@ describe('PostageStamp', function () {
           batch.initialPaymentPerChunk,
           batch.depth,
           batch.bucketDepth,
-          batch.nonce,
-          batch.immutable
+          batch.nonce
         );
         const stamp = await postageStampStamper.batches(batch.id);
         expect(stamp[0]).to.equal(stamper);
         expect(stamp[1]).to.equal(batch.depth);
         expect(stamp[2]).to.equal(batch.bucketDepth);
-        expect(stamp[3]).to.equal(batch.immutable);
-        expect(stamp[4]).to.equal(expectedNormalisedBalance);
+        expect(stamp[3]).to.equal(expectedNormalisedBalance);
       });
 
       it('should report the correct remaining balance', async function () {
@@ -182,8 +176,7 @@ describe('PostageStamp', function () {
           batch.initialPaymentPerChunk,
           batch.depth,
           batch.bucketDepth,
-          batch.nonce,
-          batch.immutable
+          batch.nonce
         );
         const buyStampBlock = await getBlockNumber();
 
@@ -227,8 +220,7 @@ describe('PostageStamp', function () {
           initialPaymentPerChunk0,
           batch.depth,
           batch.bucketDepth,
-          nonce0,
-          batch.immutable
+          nonce0
         );
         const batch0 = computeBatchId(stamper, nonce0);
         expect(batch0).equal(await postageStampStamper.firstBatchId());
@@ -242,8 +234,7 @@ describe('PostageStamp', function () {
           initialPaymentPerChunk1,
           batch.depth,
           batch.bucketDepth,
-          nonce1,
-          batch.immutable
+          nonce1
         );
         const batch1 = computeBatchId(stamper, nonce1);
         expect(batch1).equal(await postageStampStamper.firstBatchId());
@@ -255,8 +246,7 @@ describe('PostageStamp', function () {
           initialPaymentPerChunk2,
           batch.depth,
           batch.bucketDepth,
-          nonce2,
-          batch.immutable
+          nonce2
         );
 
         const batch2 = computeBatchId(stamper, nonce2);
@@ -269,8 +259,7 @@ describe('PostageStamp', function () {
         expect(stamp[0]).to.equal(stamper);
         expect(stamp[1]).to.equal(batch.depth);
         expect(stamp[2]).to.equal(batch.bucketDepth);
-        expect(stamp[3]).to.equal(batch.immutable);
-        expect(stamp[4]).to.equal(expectedNormalisedBalance2);
+        expect(stamp[3]).to.equal(expectedNormalisedBalance2);
       });
 
       it('should transfer the token', async function () {
@@ -279,8 +268,7 @@ describe('PostageStamp', function () {
           batch.initialPaymentPerChunk,
           batch.depth,
           batch.bucketDepth,
-          batch.nonce,
-          batch.immutable
+          batch.nonce
         );
         expect(await token.balanceOf(stamper)).to.equal(0);
         expect(await token.balanceOf(postageStampStamper.address)).to.equal(transferAmount);
@@ -293,8 +281,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk + 1,
             batch.depth,
             batch.bucketDepth,
-            batch.nonce,
-            batch.immutable
+            batch.nonce
           )
         ).to.be.revertedWith(errors.erc20.exceedsBalance);
       });
@@ -306,8 +293,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk,
             batch.depth,
             0,
-            batch.nonce,
-            batch.immutable
+            batch.nonce
           )
         ).to.be.revertedWith(errors.createBatch.invalidDepth);
       });
@@ -319,8 +305,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk,
             batch.depth,
             batch.depth + 1,
-            batch.nonce,
-            batch.immutable
+            batch.nonce
           )
         ).to.be.revertedWith(errors.createBatch.invalidDepth);
       });
@@ -332,8 +317,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk,
             batch.depth,
             batch.depth,
-            batch.nonce,
-            batch.immutable
+            batch.nonce
           )
         ).to.be.revertedWith(errors.createBatch.invalidDepth);
       });
@@ -344,8 +328,7 @@ describe('PostageStamp', function () {
           batch.initialPaymentPerChunk,
           batch.depth,
           batch.bucketDepth,
-          batch.nonce,
-          batch.immutable
+          batch.nonce
         );
         await expect(
           postageStampStamper.createBatch(
@@ -353,8 +336,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk,
             batch.depth,
             batch.bucketDepth,
-            batch.nonce,
-            batch.immutable
+            batch.nonce
           )
         ).to.be.revertedWith(errors.createBatch.alreadyExists);
       });
@@ -369,16 +351,14 @@ describe('PostageStamp', function () {
           initialPaymentPerChunk0,
           batch.depth,
           batch.bucketDepth,
-          batch.nonce,
-          batch.immutable
+          batch.nonce
         );
 
         const stamp = await postageStampStamper.batches(batch.id);
         expect(stamp[0]).to.equal(stamper);
         expect(stamp[1]).to.equal(batch.depth);
         expect(stamp[2]).to.equal(batch.bucketDepth);
-        expect(stamp[3]).to.equal(batch.immutable);
-        expect(stamp[4]).to.equal(expectedNormalisedBalance);
+        expect(stamp[3]).to.equal(expectedNormalisedBalance);
         expect(await postageStampStamper.isBatchesTreeEmpty()).equal(false);
 
         mineNBlocks(10);
@@ -391,7 +371,7 @@ describe('PostageStamp', function () {
         const postageStamp = await ethers.getContract('PostageStamp', deployer);
         await postageStamp.pause();
         await expect(
-          postageStamp.createBatch(stamper, 0, batch.depth, batch.bucketDepth, batch.nonce, batch.immutable)
+          postageStamp.createBatch(stamper, 0, batch.depth, batch.bucketDepth, batch.nonce)
         ).to.be.revertedWith(errors.createBatch.paused);
       });
 
@@ -404,8 +384,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk,
             batch.depth,
             batch.bucketDepth,
-            batch.nonce,
-            batch.immutable
+            batch.nonce
           )
         ).to.be.revertedWith(errors.createBatch.paused);
         await postage_p.unPause();
@@ -417,16 +396,14 @@ describe('PostageStamp', function () {
           batch.initialPaymentPerChunk,
           batch.depth,
           batch.bucketDepth,
-          batch.nonce,
-          batch.immutable
+          batch.nonce
         );
 
         const stamp = await postageStampStamper.batches(batch.id);
         expect(stamp[0]).to.equal(stamper);
         expect(stamp[1]).to.equal(batch.depth);
         expect(stamp[2]).to.equal(batch.bucketDepth);
-        expect(stamp[3]).to.equal(batch.immutable);
-        expect(stamp[4]).to.equal(expectedNormalisedBalance);
+        expect(stamp[3]).to.equal(expectedNormalisedBalance);
       });
 
       it('should delete expired batches', async function () {
@@ -443,8 +420,7 @@ describe('PostageStamp', function () {
           initialPaymentPerChunk0,
           batch.depth,
           batch.bucketDepth,
-          nonce0,
-          batch.immutable
+          nonce0
         );
 
         const batch0 = computeBatchId(stamper, nonce0);
@@ -459,8 +435,7 @@ describe('PostageStamp', function () {
           initialPaymentPerChunk1,
           batch.depth,
           batch.bucketDepth,
-          nonce1,
-          batch.immutable
+          nonce1
         );
 
         const batch1 = computeBatchId(stamper, nonce1);
@@ -475,8 +450,7 @@ describe('PostageStamp', function () {
           initialPaymentPerChunk2,
           batch.depth,
           batch.bucketDepth,
-          nonce2,
-          batch.immutable
+          nonce2
         );
 
         const batch2 = computeBatchId(stamper, nonce2);
@@ -514,8 +488,7 @@ describe('PostageStamp', function () {
           initialPaymentPerChunk0,
           batch.depth,
           batch.bucketDepth,
-          nonce0,
-          batch.immutable
+          nonce0
         );
 
         const buyStamp0Block = await getBlockNumber();
@@ -541,8 +514,7 @@ describe('PostageStamp', function () {
           initialPaymentPerChunk1,
           batch.depth,
           batch.bucketDepth,
-          nonce1,
-          batch.immutable
+          nonce1
         );
 
         const buyStamp1Block = await getBlockNumber();
@@ -576,8 +548,7 @@ describe('PostageStamp', function () {
           initialPaymentPerChunk2,
           batch.depth,
           batch.bucketDepth,
-          nonce2,
-          batch.immutable
+          nonce2
         );
 
         const buyStamp2Block = await getBlockNumber();
@@ -650,7 +621,6 @@ describe('PostageStamp', function () {
           nonce: '0x000000000000000000000000000000000000000000000000000000000000abce',
           initialPaymentPerChunk: price0 * initialBatchBlocks,
           depth: 17,
-          immutable: false,
           bucketDepth: 16,
         };
 
@@ -668,8 +638,7 @@ describe('PostageStamp', function () {
           batch.initialPaymentPerChunk,
           batch.depth,
           batch.bucketDepth,
-          batch.nonce,
-          batch.immutable
+          batch.nonce
         );
       });
 
@@ -727,7 +696,6 @@ describe('PostageStamp', function () {
           nonce: '0x000000000000000000000000000000000000000000000000000000000000abc1',
           initialPaymentPerChunk: price0 * batch2Blocks,
           depth: 17,
-          immutable: false,
           bucketDepth: 16,
         };
         const batch2TransferAmount = price0 * batch2Blocks * 2 ** batch2.depth;
@@ -739,8 +707,7 @@ describe('PostageStamp', function () {
           batch2.initialPaymentPerChunk,
           batch2.depth,
           batch2.bucketDepth,
-          batch2.nonce,
-          batch2.immutable
+          batch2.nonce
         );
 
         const batch2Id = computeBatchId(stamper, batch2.nonce);
@@ -779,7 +746,6 @@ describe('PostageStamp', function () {
           nonce: '0x000000000000000000000000000000000000000000000000000000000000abce',
           initialPaymentPerChunk: price0 * initialBatchBlocks,
           depth: 17,
-          immutable: false,
           bucketDepth: 16,
         };
 
@@ -798,8 +764,7 @@ describe('PostageStamp', function () {
           batch.initialPaymentPerChunk,
           batch.depth,
           batch.bucketDepth,
-          batch.nonce,
-          batch.immutable
+          batch.nonce
         );
       });
 
@@ -833,7 +798,6 @@ describe('PostageStamp', function () {
         const stamp = await postageStamp.batches(batch.id);
         expect(stamp.owner).to.equal(stamper);
         expect(stamp.depth).to.equal(newDepth);
-        expect(stamp.immutableFlag).to.equal(batch.immutable);
         expect(stamp.normalisedBalance).to.equal(expectedNormalisedBalanceAfter);
       });
 
@@ -883,7 +847,6 @@ describe('PostageStamp', function () {
           nonce: '0x000000000000000000000000000000000000000000000000000000000000abc1',
           initialPaymentPerChunk: price0 * batch2Blocks,
           depth: 17,
-          immutable: false,
           bucketDepth: 16,
         };
         const batch2TransferAmount = price0 * batch2Blocks * 2 ** batch2.depth;
@@ -895,8 +858,7 @@ describe('PostageStamp', function () {
           batch2.initialPaymentPerChunk,
           batch2.depth,
           batch2.bucketDepth,
-          batch2.nonce,
-          batch2.immutable
+          batch2.nonce
         );
 
         const batch2Id = computeBatchId(stamper, batch2.nonce);
@@ -916,7 +878,6 @@ describe('PostageStamp', function () {
           nonce: '0x000000000000000000000000000000000000000000000000000000000000abc1',
           initialPaymentPerChunk: price0 * batch2Blocks,
           depth: 17,
-          immutable: false,
           bucketDepth: 16,
         };
         const batch2TransferAmount = price0 * batch2Blocks * 2 ** batch2.depth;
@@ -928,8 +889,7 @@ describe('PostageStamp', function () {
           batch2.initialPaymentPerChunk,
           batch2.depth,
           batch2.bucketDepth,
-          batch2.nonce,
-          batch2.immutable
+          batch2.nonce
         );
 
         const batch2Id = computeBatchId(stamper, batch2.nonce);
@@ -1044,7 +1004,6 @@ describe('PostageStamp', function () {
           nonce: '0x000000000000000000000000000000000000000000000000000000000000abce',
           initialPaymentPerChunk: price0 * initialBatch0Blocks,
           depth: 17,
-          immutable: false,
           bucketDepth: 16,
         };
 
@@ -1058,15 +1017,13 @@ describe('PostageStamp', function () {
           batch0.initialPaymentPerChunk,
           batch0.depth,
           batch0.bucketDepth,
-          batch0.nonce,
-          batch0.immutable
+          batch0.nonce
         );
 
         batch1 = {
           nonce: '0x000000000000000000000000000000000000000000000000000000000000abcf',
           initialPaymentPerChunk: price0 * initialBatch1Blocks,
           depth: 17,
-          immutable: false,
           bucketDepth: 16,
         };
 
@@ -1082,15 +1039,13 @@ describe('PostageStamp', function () {
           batch1.initialPaymentPerChunk,
           batch1.depth,
           batch1.bucketDepth,
-          batch1.nonce,
-          batch1.immutable
+          batch1.nonce
         );
 
         batch2 = {
           nonce: '0x000000000000000000000000000000000000000000000000000000000000abc1',
           initialPaymentPerChunk: price0 * initialBatch2Blocks,
           depth: 17,
-          immutable: false,
           bucketDepth: 16,
         };
 
@@ -1106,8 +1061,7 @@ describe('PostageStamp', function () {
           batch2.initialPaymentPerChunk,
           batch2.depth,
           batch2.bucketDepth,
-          batch2.nonce,
-          batch2.immutable
+          batch2.nonce
         );
       });
 
@@ -1173,7 +1127,6 @@ describe('PostageStamp', function () {
           nonce: '0x000000000000000000000000000000000000000000000000000000000000abcd',
           initialPaymentPerChunk: 10240,
           depth: 17,
-          immutable: false,
           bucketDepth: 16,
         };
 
@@ -1191,8 +1144,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk,
             batch.depth,
             batch.bucketDepth,
-            batch.nonce,
-            batch.immutable
+            batch.nonce
           )
         )
           .to.emit(postageStampStamper, 'BatchCreated')
@@ -1202,8 +1154,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk,
             stamper,
             batch.depth,
-            batch.bucketDepth,
-            batch.immutable
+            batch.bucketDepth
           );
       });
 
@@ -1213,33 +1164,31 @@ describe('PostageStamp', function () {
           batch.initialPaymentPerChunk,
           batch.depth,
           batch.bucketDepth,
-          batch.nonce,
-          batch.immutable
+          batch.nonce
         );
         const stamp = await postageStampStamper.batches(batch.id);
         expect(stamp[0]).to.equal(stamper);
         expect(stamp[1]).to.equal(batch.depth);
         expect(stamp[2]).to.equal(batch.bucketDepth);
-        expect(stamp[3]).to.equal(batch.immutable);
-        expect(stamp[4]).to.equal(batch.initialPaymentPerChunk);
+        expect(stamp[3]).to.equal(batch.initialPaymentPerChunk);
       });
 
       it('should keep batches ordered by normalisedBalance', async function () {
         const nonce0 = '0x0000000000000000000000000000000000000000000000000000000000001234';
         const batch0 = computeBatchId(stamper, nonce0);
 
-        await postageStampStamper.copyBatch(stamper, 3300, batch.depth, batch.bucketDepth, batch0, batch.immutable);
+        await postageStampStamper.copyBatch(stamper, 3300, batch.depth, batch.bucketDepth, batch0);
         expect(batch0).equal(await postageStampStamper.firstBatchId());
 
         const nonce1 = '0x0000000000000000000000000000000000000000000000000000000000001235';
         const batch1 = computeBatchId(stamper, nonce1);
 
-        await postageStampStamper.copyBatch(stamper, 11, batch.depth, batch.bucketDepth, batch1, batch.immutable);
+        await postageStampStamper.copyBatch(stamper, 11, batch.depth, batch.bucketDepth, batch1);
         expect(batch1).equal(await postageStampStamper.firstBatchId());
 
         const nonce2 = '0x0000000000000000000000000000000000000000000000000000000000001236';
         const batch2 = computeBatchId(stamper, nonce2);
-        await postageStampStamper.copyBatch(stamper, 2200, batch.depth, batch.bucketDepth, batch2, batch.immutable);
+        await postageStampStamper.copyBatch(stamper, 2200, batch.depth, batch.bucketDepth, batch2);
         expect(batch1).equal(await postageStampStamper.firstBatchId());
         expect(batch2).not.equal(await postageStampStamper.firstBatchId());
 
@@ -1247,8 +1196,7 @@ describe('PostageStamp', function () {
         expect(stamp[0]).to.equal(stamper);
         expect(stamp[1]).to.equal(batch.depth);
         expect(stamp[2]).to.equal(batch.bucketDepth);
-        expect(stamp[3]).to.equal(batch.immutable);
-        expect(stamp[4]).to.equal(11);
+        expect(stamp[3]).to.equal(11);
       });
 
       // it('should transfer the token', async function () {
@@ -1283,8 +1231,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk,
             batch.depth,
             batch.bucketDepth,
-            batch.nonce,
-            batch.immutable
+            batch.nonce
           )
         ).to.be.revertedWith('ZeroAddress()');
       });
@@ -1296,8 +1243,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk,
             batch.depth,
             0,
-            batch.nonce,
-            batch.immutable
+            batch.nonce
           )
         ).to.be.revertedWith('InvalidDepth()');
       });
@@ -1309,8 +1255,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk,
             batch.depth,
             batch.depth + 1,
-            batch.nonce,
-            batch.immutable
+            batch.nonce
           )
         ).to.be.revertedWith('InvalidDepth()');
       });
@@ -1322,8 +1267,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk,
             batch.depth,
             batch.depth,
-            batch.nonce,
-            batch.immutable
+            batch.nonce
           )
         ).to.be.revertedWith('InvalidDepth()');
       });
@@ -1334,17 +1278,16 @@ describe('PostageStamp', function () {
           1000,
           batch.depth,
           batch.bucketDepth,
-          batch.nonce,
-          batch.immutable
+          batch.nonce
         );
         await expect(
-          postageStampStamper.copyBatch(stamper, 1000, batch.depth, batch.bucketDepth, batch.nonce, batch.immutable)
+          postageStampStamper.copyBatch(stamper, 1000, batch.depth, batch.bucketDepth, batch.nonce)
         ).to.be.revertedWith('BatchExists()');
       });
 
       it('should not allow normalized balance to be zero', async function () {
         await expect(
-          postageStampStamper.copyBatch(stamper, 0, batch.depth, batch.bucketDepth, batch.nonce, batch.immutable)
+          postageStampStamper.copyBatch(stamper, 0, batch.depth, batch.bucketDepth, batch.nonce)
         ).to.be.revertedWith('ZeroBalance()');
       });
 
@@ -1354,15 +1297,13 @@ describe('PostageStamp', function () {
           batch.initialPaymentPerChunk,
           batch.depth,
           batch.bucketDepth,
-          batch.nonce,
-          batch.immutable
+          batch.nonce
         );
         const stamp = await postageStampStamper.batches(batch.id);
         expect(stamp[0]).to.equal(stamper);
         expect(stamp[1]).to.equal(batch.depth);
         expect(stamp[2]).to.equal(batch.bucketDepth);
-        expect(stamp[3]).to.equal(batch.immutable);
-        expect(stamp[4]).to.equal(batch.initialPaymentPerChunk);
+        expect(stamp[3]).to.equal(batch.initialPaymentPerChunk);
         const isEmpty = await postageStampStamper.isBatchesTreeEmpty();
         expect(isEmpty).equal(false);
       });
@@ -1371,7 +1312,7 @@ describe('PostageStamp', function () {
         const postageStamp = await ethers.getContract('PostageStamp', deployer);
         await postageStamp.pause();
         await expect(
-          postageStamp.copyBatch(stamper, 0, batch.depth, batch.bucketDepth, batch.nonce, batch.immutable)
+          postageStamp.copyBatch(stamper, 0, batch.depth, batch.bucketDepth, batch.nonce)
         ).to.be.revertedWith('Pausable: paused');
       });
 
@@ -1389,8 +1330,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk,
             batch.depth,
             batch.bucketDepth,
-            batch.nonce,
-            batch.immutable
+            batch.nonce
           )
         )
           .to.emit(postageStampStamper, 'BatchCreated')
@@ -1400,11 +1340,10 @@ describe('PostageStamp', function () {
             expectedNormalisedBalance,
             stamper,
             batch.depth,
-            batch.bucketDepth,
-            batch.immutable
+            batch.bucketDepth
           );
         const stamp = await postageStampStamper.batches(batch.id);
-        expect(stamp[4]).to.equal(expectedNormalisedBalance);
+        expect(stamp[3]).to.equal(expectedNormalisedBalance);
       });
 
       it('should include pending totalOutpayment in the normalised balance', async function () {
@@ -1421,8 +1360,7 @@ describe('PostageStamp', function () {
             batch.initialPaymentPerChunk,
             batch.depth,
             batch.bucketDepth,
-            batch.nonce,
-            batch.immutable
+            batch.nonce
           )
         )
           .to.emit(postageStampStamper, 'BatchCreated')
@@ -1432,11 +1370,10 @@ describe('PostageStamp', function () {
             expectedNormalisedBalance,
             stamper,
             batch.depth,
-            batch.bucketDepth,
-            batch.immutable
+            batch.bucketDepth
           );
         const stamp = await postageStampStamper.batches(batch.id);
-        expect(stamp[4]).to.equal(expectedNormalisedBalance);
+        expect(stamp[3]).to.equal(expectedNormalisedBalance);
       });
     });
   });

--- a/test/PostageStamp.test.ts
+++ b/test/PostageStamp.test.ts
@@ -143,14 +143,7 @@ describe('PostageStamp', function () {
           )
         )
           .to.emit(postageStampStamper, 'BatchCreated')
-          .withArgs(
-            batch.id,
-            transferAmount,
-            expectedNormalisedBalance,
-            stamper,
-            batch.depth,
-            batch.bucketDepth
-          );
+          .withArgs(batch.id, transferAmount, expectedNormalisedBalance, stamper, batch.depth, batch.bucketDepth);
       });
 
       it('should store the batch', async function () {
@@ -215,13 +208,7 @@ describe('PostageStamp', function () {
         const initialPaymentPerChunk2 = 2200;
 
         const nonce0 = '0x0000000000000000000000000000000000000000000000000000000000001234';
-        await postageStampStamper.createBatch(
-          stamper,
-          initialPaymentPerChunk0,
-          batch.depth,
-          batch.bucketDepth,
-          nonce0
-        );
+        await postageStampStamper.createBatch(stamper, initialPaymentPerChunk0, batch.depth, batch.bucketDepth, nonce0);
         const batch0 = computeBatchId(stamper, nonce0);
         expect(batch0).equal(await postageStampStamper.firstBatchId());
 
@@ -229,25 +216,13 @@ describe('PostageStamp', function () {
         const expectedNormalisedBalance1 = initialPaymentPerChunk1 + blocksElapsed * price0;
 
         const nonce1 = '0x0000000000000000000000000000000000000000000000000000000000001235';
-        await postageStampStamper.createBatch(
-          stamper,
-          initialPaymentPerChunk1,
-          batch.depth,
-          batch.bucketDepth,
-          nonce1
-        );
+        await postageStampStamper.createBatch(stamper, initialPaymentPerChunk1, batch.depth, batch.bucketDepth, nonce1);
         const batch1 = computeBatchId(stamper, nonce1);
         expect(batch1).equal(await postageStampStamper.firstBatchId());
         const blocksElapsed2 = (await getBlockNumber()) - setPrice0Block;
 
         const nonce2 = '0x0000000000000000000000000000000000000000000000000000000000001236';
-        await postageStampStamper.createBatch(
-          stamper,
-          initialPaymentPerChunk2,
-          batch.depth,
-          batch.bucketDepth,
-          nonce2
-        );
+        await postageStampStamper.createBatch(stamper, initialPaymentPerChunk2, batch.depth, batch.bucketDepth, nonce2);
 
         const batch2 = computeBatchId(stamper, nonce2);
         expect(batch2).equal(await postageStampStamper.firstBatchId());
@@ -288,13 +263,7 @@ describe('PostageStamp', function () {
 
       it('should not allow zero as bucket depth', async function () {
         await expect(
-          postageStampStamper.createBatch(
-            stamper,
-            batch.initialPaymentPerChunk,
-            batch.depth,
-            0,
-            batch.nonce
-          )
+          postageStampStamper.createBatch(stamper, batch.initialPaymentPerChunk, batch.depth, 0, batch.nonce)
         ).to.be.revertedWith(errors.createBatch.invalidDepth);
       });
 
@@ -312,13 +281,7 @@ describe('PostageStamp', function () {
 
       it('should not allow bucket depth equal to depth', async function () {
         await expect(
-          postageStampStamper.createBatch(
-            stamper,
-            batch.initialPaymentPerChunk,
-            batch.depth,
-            batch.depth,
-            batch.nonce
-          )
+          postageStampStamper.createBatch(stamper, batch.initialPaymentPerChunk, batch.depth, batch.depth, batch.nonce)
         ).to.be.revertedWith(errors.createBatch.invalidDepth);
       });
 
@@ -415,13 +378,7 @@ describe('PostageStamp', function () {
         await mintAndApprove(deployer, stamper, postageStampStamper.address, transferAmount0.toString());
 
         const nonce0 = '0x0000000000000000000000000000000000000000000000000000000000001234';
-        await postageStampStamper.createBatch(
-          stamper,
-          initialPaymentPerChunk0,
-          batch.depth,
-          batch.bucketDepth,
-          nonce0
-        );
+        await postageStampStamper.createBatch(stamper, initialPaymentPerChunk0, batch.depth, batch.bucketDepth, nonce0);
 
         const batch0 = computeBatchId(stamper, nonce0);
         expect(await postageStampStamper.firstBatchId()).to.equal(batch0);
@@ -430,13 +387,7 @@ describe('PostageStamp', function () {
         await mintAndApprove(deployer, stamper, postageStampStamper.address, transferAmount1.toString());
 
         const nonce1 = '0x0000000000000000000000000000000000000000000000000000000000001235';
-        await postageStampStamper.createBatch(
-          stamper,
-          initialPaymentPerChunk1,
-          batch.depth,
-          batch.bucketDepth,
-          nonce1
-        );
+        await postageStampStamper.createBatch(stamper, initialPaymentPerChunk1, batch.depth, batch.bucketDepth, nonce1);
 
         const batch1 = computeBatchId(stamper, nonce1);
         expect(await postageStampStamper.firstBatchId()).to.equal(batch1);
@@ -445,13 +396,7 @@ describe('PostageStamp', function () {
         await mintAndApprove(deployer, stamper, postageStampStamper.address, transferAmount2.toString());
 
         const nonce2 = '0x0000000000000000000000000000000000000000000000000000000000001236';
-        await postageStampStamper.createBatch(
-          stamper,
-          initialPaymentPerChunk2,
-          batch.depth,
-          batch.bucketDepth,
-          nonce2
-        );
+        await postageStampStamper.createBatch(stamper, initialPaymentPerChunk2, batch.depth, batch.bucketDepth, nonce2);
 
         const batch2 = computeBatchId(stamper, nonce2);
         expect(await postageStampStamper.firstBatchId()).to.equal(batch1);
@@ -483,13 +428,7 @@ describe('PostageStamp', function () {
         await mintAndApprove(deployer, stamper, postageStampStamper.address, transferAmount0.toString());
 
         const nonce0 = '0x0000000000000000000000000000000000000000000000000000000000001234';
-        await postageStampStamper.createBatch(
-          stamper,
-          initialPaymentPerChunk0,
-          batch.depth,
-          batch.bucketDepth,
-          nonce0
-        );
+        await postageStampStamper.createBatch(stamper, initialPaymentPerChunk0, batch.depth, batch.bucketDepth, nonce0);
 
         const buyStamp0Block = await getBlockNumber();
 
@@ -509,13 +448,7 @@ describe('PostageStamp', function () {
         await mintAndApprove(deployer, stamper, postageStampStamper.address, transferAmount1.toString());
 
         const nonce1 = '0x0000000000000000000000000000000000000000000000000000000000001235';
-        await postageStampStamper.createBatch(
-          stamper,
-          initialPaymentPerChunk1,
-          batch.depth,
-          batch.bucketDepth,
-          nonce1
-        );
+        await postageStampStamper.createBatch(stamper, initialPaymentPerChunk1, batch.depth, batch.bucketDepth, nonce1);
 
         const buyStamp1Block = await getBlockNumber();
 
@@ -543,13 +476,7 @@ describe('PostageStamp', function () {
         await mintAndApprove(deployer, stamper, postageStampStamper.address, transferAmount2.toString());
 
         const nonce2 = '0x0000000000000000000000000000000000000000000000000000000000001236';
-        await postageStampStamper.createBatch(
-          stamper,
-          initialPaymentPerChunk2,
-          batch.depth,
-          batch.bucketDepth,
-          nonce2
-        );
+        await postageStampStamper.createBatch(stamper, initialPaymentPerChunk2, batch.depth, batch.bucketDepth, nonce2);
 
         const buyStamp2Block = await getBlockNumber();
 
@@ -1148,14 +1075,7 @@ describe('PostageStamp', function () {
           )
         )
           .to.emit(postageStampStamper, 'BatchCreated')
-          .withArgs(
-            batch.nonce,
-            transferAmount,
-            batch.initialPaymentPerChunk,
-            stamper,
-            batch.depth,
-            batch.bucketDepth
-          );
+          .withArgs(batch.nonce, transferAmount, batch.initialPaymentPerChunk, stamper, batch.depth, batch.bucketDepth);
       });
 
       it('should store the batch', async function () {
@@ -1199,31 +1119,6 @@ describe('PostageStamp', function () {
         expect(stamp[3]).to.equal(11);
       });
 
-      // it('should transfer the token', async function () {
-      //   await postageStampStamper.copyBatch(
-      //     stamper,
-      //     batch.initialPaymentPerChunk,
-      //     batch.depth,
-      //     batch.bucketDepth,
-      //     batch.nonce,
-      //     batch.immutable
-      //   );
-      //   expect(await token.balanceOf(stamper)).to.equal(0);
-      // });
-
-      // it('should not create batch if insufficient funds', async function () {
-      //   await expect(
-      //     postageStampStamper.copyBatch(
-      //       stamper,
-      //       batch.initialPaymentPerChunk + 1,
-      //       batch.depth,
-      //       batch.bucketDepth,
-      //       batch.nonce,
-      //       batch.immutable
-      //     )
-      //   ).to.be.revertedWith(errors.erc20.exceedsBalance);
-      // });
-
       it('should not allow zero address as owner', async function () {
         await expect(
           postageStampStamper.copyBatch(
@@ -1238,13 +1133,7 @@ describe('PostageStamp', function () {
 
       it('should not allow zero as bucket depth', async function () {
         await expect(
-          postageStampStamper.copyBatch(
-            stamper,
-            batch.initialPaymentPerChunk,
-            batch.depth,
-            0,
-            batch.nonce
-          )
+          postageStampStamper.copyBatch(stamper, batch.initialPaymentPerChunk, batch.depth, 0, batch.nonce)
         ).to.be.revertedWith('InvalidDepth()');
       });
 
@@ -1262,24 +1151,12 @@ describe('PostageStamp', function () {
 
       it('should not allow bucket depth equal to depth', async function () {
         await expect(
-          postageStampStamper.copyBatch(
-            stamper,
-            batch.initialPaymentPerChunk,
-            batch.depth,
-            batch.depth,
-            batch.nonce
-          )
+          postageStampStamper.copyBatch(stamper, batch.initialPaymentPerChunk, batch.depth, batch.depth, batch.nonce)
         ).to.be.revertedWith('InvalidDepth()');
       });
 
       it('should not allow duplicate batch', async function () {
-        await postageStampStamper.copyBatch(
-          stamper,
-          1000,
-          batch.depth,
-          batch.bucketDepth,
-          batch.nonce
-        );
+        await postageStampStamper.copyBatch(stamper, 1000, batch.depth, batch.bucketDepth, batch.nonce);
         await expect(
           postageStampStamper.copyBatch(stamper, 1000, batch.depth, batch.bucketDepth, batch.nonce)
         ).to.be.revertedWith('BatchExists()');
@@ -1334,14 +1211,7 @@ describe('PostageStamp', function () {
           )
         )
           .to.emit(postageStampStamper, 'BatchCreated')
-          .withArgs(
-            batch.id,
-            transferAmount,
-            expectedNormalisedBalance,
-            stamper,
-            batch.depth,
-            batch.bucketDepth
-          );
+          .withArgs(batch.id, transferAmount, expectedNormalisedBalance, stamper, batch.depth, batch.bucketDepth);
         const stamp = await postageStampStamper.batches(batch.id);
         expect(stamp[3]).to.equal(expectedNormalisedBalance);
       });
@@ -1364,14 +1234,7 @@ describe('PostageStamp', function () {
           )
         )
           .to.emit(postageStampStamper, 'BatchCreated')
-          .withArgs(
-            batch.id,
-            transferAmount,
-            expectedNormalisedBalance,
-            stamper,
-            batch.depth,
-            batch.bucketDepth
-          );
+          .withArgs(batch.id, transferAmount, expectedNormalisedBalance, stamper, batch.depth, batch.bucketDepth);
         const stamp = await postageStampStamper.batches(batch.id);
         expect(stamp[3]).to.equal(expectedNormalisedBalance);
       });

--- a/test/Redistribution.test.ts
+++ b/test/Redistribution.test.ts
@@ -309,7 +309,6 @@ describe('Redistribution', function () {
       initialPaymentPerChunk: 20000000000,
       depth: 17,
       bucketDepth: 16,
-      immutable: false,
       blocks: 100,
     };
     let stampCreatedBlock: number;
@@ -339,8 +338,7 @@ describe('Redistribution', function () {
         batch.initialPaymentPerChunk,
         batch.depth,
         batch.bucketDepth,
-        batch.nonce,
-        batch.immutable
+        batch.nonce
       );
 
       stampCreatedBlock = await getBlockNumber();
@@ -1217,8 +1215,7 @@ describe('Redistribution', function () {
               initialPaymentPerChunk,
               batch.depth,
               batch.bucketDepth,
-              '0x00000000000000000000000000000000000000000000000000000000b0bafe77',
-              batch.immutable
+              '0x00000000000000000000000000000000000000000000000000000000b0bafe77'
             );
             await mineNBlocks(1); // in order to expire batch
             await postage.expireLimited(1); // remove batch

--- a/test/Redistribution.test.ts
+++ b/test/Redistribution.test.ts
@@ -333,13 +333,7 @@ describe('Redistribution', function () {
       await mintAndApprove(deployer, stamper, postage.address, transferAmount.toString());
 
       await postage.expireLimited(maxInt256); //for testing
-      await postage.createBatch(
-        stamper,
-        batch.initialPaymentPerChunk,
-        batch.depth,
-        batch.bucketDepth,
-        batch.nonce
-      );
+      await postage.createBatch(stamper, batch.initialPaymentPerChunk, batch.depth, batch.bucketDepth, batch.nonce);
 
       stampCreatedBlock = await getBlockNumber();
 

--- a/test/util/tools.ts
+++ b/test/util/tools.ts
@@ -241,8 +241,7 @@ export async function copyBatchForClaim(
     initialBalance, // initial balance per chunk
     postageDepth, // depth
     16, // bucketdepth
-    batchId,
-    true // immutable
+    batchId
   );
   await tx.wait();
 


### PR DESCRIPTION
## Summary

Removes the legacy `immutableFlag` from `PostageStamp`. The field was stored and exposed on-chain but never enforced — not in `PostageStamp`, not in `Redistribution`, and not at the network level. Keeping it implied a guarantee that does not exist.

Closes #317 (cleanup path).

## Changes

- Remove `immutableFlag` from `Batch` / `ImportBatch` structs
- Drop `_immutable` from `createBatch()` and `copyBatch()`
- Remove `batchImmutableFlag()` view and `immutableFlag` from `BatchCreated` event
- Update `Redistribution.stampFunction()` batch destructuring
- Update tests, echidna harnesses, migration scripts, and `docs/POSTAGE_STAMP.md`

## Breaking changes

This is a **breaking ABI change** for the next `PostageStamp` deployment:

| Before | After |
|---|---|
| `createBatch(owner, balance, depth, bucketDepth, nonce, immutable)` | `createBatch(owner, balance, depth, bucketDepth, nonce)` |
| `copyBatch(owner, balance, depth, bucketDepth, batchId, immutable)` | `copyBatch(owner, balance, depth, bucketDepth, batchId)` |
| `batchImmutableFlag(batchId)` | removed |
| `BatchCreated(..., immutableFlag)` | `BatchCreated(...)` (no flag) |
| `batches(id)` returns 6 fields | returns 5 fields |

Existing mainnet batches are unaffected until the next contract migration.

## Follow-up work (not in this PR)

### Swarm / Bee docs
- Remove or rewrite references to on-chain batch immutability in Bee and Swarm docs
- Clarify that Bee's local overwrite protection (if any) is a node-side safeguard, not a network guarantee
- Document the new `createBatch` / `copyBatch` signatures for integrators

### Bee node
- Update postage batch purchase / creation calls to drop the `_immutable` argument
- Remove reads of `batchImmutableFlag()` if used anywhere
- **Keep** local DB overwrite protection if still desired — that behavior is independent of the contract field
- No change needed to chunk stamping logic unless Bee was branching on the on-chain flag (it had no network effect anyway)

### Batch migration
- Migration JSON exports may still contain an `immutable` field — safe to ignore on import (updated `import.ts` / `import.sh` / `copy` task no longer pass it)
- Next migration run should use the updated `copyBatch` signature
- Verify `batch-migration` tooling and any offline export scripts drop the field or treat it as legacy metadata only

### Future (separate RFC)
Network-level immutability + depth-lock is a protocol change (Bee overwrite policy, conflict resolution, redistribution) — not a contract-only toggle. Track separately if we pursue storage guarantees.

## Test plan

- [x] `npx hardhat compile`
- [x] `npx hardhat test test/PostageStamp.test.ts`
- [x] `npx hardhat test test/Redistribution.test.ts`